### PR TITLE
Add rewrite_methods to Redefiner, replacing untyped_methods when type checking is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Minor features that don't break backwards compatibility are released as patches.
 
 ### Added
 
+- `rewrite_methods` replaces the `untyped_methods` shim when `config.type_checking = false`. Methods are rewritten directly via `class_eval` after stripping type annotations from the signature using `MethodProxy#rewrite_signature`. No more `define_method` + `super` dispatch overhead.
+- Benchmark: keyword arg methods are 4.67x faster than the old shim. Positional arg methods match plain Ruby performance.
 - Support dynamic expressions in methods and return types at runtime (like `type()` already does)
 - `Boolean` type support
 - Complex types validation

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,38 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## Execution paths
+
+LowType has two paths depending on `config.type_checking`:
+
+**type_checking: true (default)**
+
+Methods are redefined via a prepended Module using `define_method`. On each call, argument types are validated against the evaluated expressions, then `super` dispatches to the original method.
+
+**type_checking: false**
+
+Methods are rewritten directly on the class. `MethodProxy#rewrite_signature` strips type annotations from the signature line in the shared `lines` array, then `class_eval(method_proxy.export)` redefines the method with a plain Ruby signature. No prepended module, no `super`, no runtime overhead beyond the method itself.
+
+The rewritten method has default values baked in from the expressions, so keyword and positional defaults work as normal Ruby defaults would.
+
+Private visibility is preserved using `klass.send(:private, method_name)` after the `class_eval`.
+
+## Benchmarks
+
+Run the benchmark with:
+
+    $ bundle exec ruby benchmarks/rewriter_benchmark.rb
+
+Results on Ruby 3.3.0 (keyword args, which is the primary use case):
+
+| Approach                   | i/s       |
+| -------------------------- | --------- |
+| Plain Ruby                 | 6,200,000 |
+| rewrite_methods (new)      | 5,130,000 |
+| untyped_methods shim (old) | 1,100,000 |
+
+The rewriter is 4.67x faster than the old shim and within 1.21x of plain Ruby.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://codeberg.org/low_ruby/low_type.

--- a/GSOC-2026-FINAL-REPORT.md
+++ b/GSOC-2026-FINAL-REPORT.md
@@ -1,0 +1,831 @@
+# Google Summer of Code 2026 — Final Work Report
+
+## Eliminating Shim Methods via Method Rewriting in LowType
+
+**Contributor:** Aditya Chauhan
+**Organization:** Ruby
+**Mentor:** Maedi
+**Program:** Google Summer of Code 2026
+
+---
+
+## 1. Project Overview
+
+The goal of this project was to improve the runtime performance and implementation of method handling in [LowType](https://github.com/low-rb/low_type) by eliminating the need for untyped shim methods when runtime type checking is disabled.
+
+LowType introduces runtime type expressions into Ruby method definitions. When type checking is disabled, the existing implementation uses untyped shim methods. Although this preserves the desired behavior, the additional shim layer can introduce unnecessary runtime overhead.
+
+The primary objective of this project was therefore to implement a method rewriting approach that removes the type annotations from the original method definition and evaluates the resulting Ruby method directly in the target class.
+
+The project required supporting changes in both LowType and its companion [Lowkey](https://github.com/low-rb/lowkey) library. These changes addressed method signature reconstruction, parameter handling, class bindings, constant resolution, type validation, and related performance issues.
+
+---
+
+# 2. Project Goals
+
+The main goals of the GSoC project were:
+
+1. Investigate the existing untyped shim implementation and its performance characteristics.
+2. Design and implement a method rewriting mechanism.
+3. Replace untyped shim methods with rewritten methods when type checking is disabled.
+4. Preserve Ruby method behavior and visibility during rewriting.
+5. Correctly resolve user-defined constants used in type expressions.
+6. Capture and preserve the appropriate class binding during class loading.
+7. Add the supporting functionality required in Lowkey and LowType.
+8. Add comprehensive tests for normal and edge-case method signatures.
+9. Benchmark the new implementation against the existing shim implementation and plain Ruby.
+10. Document the implementation and its configuration.
+
+---
+
+# 3. Summary of Accomplishments
+
+The project resulted in the following major contributions:
+
+- Added class-binding support to Lowkey's `ClassProxy`.
+- Added untyped parameter export support to `ParamProxy`.
+- Added method signature rewriting support to `MethodProxy`.
+- Fixed `ValueExpression` handling during untyped parameter export.
+- Normalized `LOWKEY_UNDEFINED` handling.
+- Fixed subclass type validation in LowType.
+- Removed repeated `Struct.new` allocation from configuration access.
+- Added class-binding capture using `TracePoint :end`.
+- Added class-level constant evaluation to the evaluator.
+- Implemented `rewrite_methods` in LowType's `Redefiner`.
+- Added support for typed, untyped, and rewrite configuration modes.
+- Preserved private method visibility during rewriting.
+- Added 13 edge-case specifications for the rewriting implementation.
+- Benchmarked rewritten methods against the existing shim implementation and plain Ruby.
+- Updated project documentation.
+
+The supporting changes have been merged according to the current project audit. The primary GSoC deliverable, `rewrite_methods`, is implemented in [LowType PR #45](https://github.com/low-rb/low_type/pull/45) and is currently under review.
+
+---
+
+# 4. Contributions to Lowkey
+
+The method rewriting implementation required several changes to Lowkey.
+
+## PR #6 — Add `class_binding` to `ClassProxy`
+
+**[Lowkey PR #6](https://github.com/low-rb/lowkey/pull/6)**
+**Status: Merged**
+
+Added `class_binding` as an `attr_accessor` to `ClassProxy`, initialized to `nil`.
+
+This allows LowType to retain the binding associated with the class body after the class has been loaded.
+
+The captured class binding is required for correctly evaluating user-defined constants in the context in which the class was originally defined.
+
+### Why this was needed
+
+Ruby constant resolution depends on the surrounding class/module context. A generic evaluation context is therefore insufficient for all type-expression cases.
+
+Storing the original class binding provides LowType with the correct context for later evaluation.
+
+---
+
+## PR #9 — Add `export(typed: false)` and `rewrite_signature`
+
+**[Lowkey PR #9](https://github.com/low-rb/lowkey/pull/9)**
+**Status: Merged**
+
+Added:
+
+```ruby
+ParamProxy#export(typed: false)
+```
+
+This allows a parameter to be exported without its LowType type annotation.
+
+The PR also added:
+
+```ruby
+MethodProxy#rewrite_signature
+```
+
+This reconstructs a method signature using untyped parameter exports and replaces the appropriate signature line in the shared source representation.
+
+### Purpose
+
+This functionality forms the foundation of method rewriting by allowing LowType's type information to be removed while retaining the original Ruby method signature.
+
+---
+
+## PR #10 — Fix `ValueExpression` unwrapping
+
+**[Lowkey PR #10](https://github.com/low-rb/lowkey/pull/10)**
+**Status: Merged**
+
+Fixed handling of `ValueExpression` objects during:
+
+```ruby
+ParamProxy#export(typed: false)
+```
+
+The implementation uses:
+
+```ruby
+defined?(ValueExpression) ? ValueExpression : nil
+```
+
+to safely check if `ValueExpression` is loaded, then uses `instance_of?` for the actual check. This avoids a `NameError` when LowType is not loaded in Lowkey's context.
+
+Two specifications were added covering:
+
+- positional parameters
+- keyword parameters
+
+This ensures that default values represented by `ValueExpression` are correctly unwrapped when generating rewritten method signatures.
+
+---
+
+## PR #11 — Normalize `LOWKEY_UNDEFINED`
+
+**[Lowkey PR #11](https://github.com/low-rb/lowkey/pull/11)**
+**Status: Merged**
+
+Fixed `proxy_factory.rb` assigning:
+
+```ruby
+':LOWKEY_UNDEFINED'
+```
+
+as a string instead of:
+
+```ruby
+:LOWKEY_UNDEFINED
+```
+
+as a symbol.
+
+The corresponding guards in `param_proxy.rb` were simplified by removing support for both representations in:
+
+- `required?`
+- `resolved_default`
+
+This normalized the internal representation and simplified the surrounding implementation.
+
+---
+
+# 5. Contributions to LowType
+
+## PR #29 — Replace strict class equality with `is_a?`
+
+**[LowType PR #29](https://github.com/low-rb/low_type/pull/29)**
+**Status: Merged**
+
+### Problem
+
+Type validation used strict class equality:
+
+```ruby
+type == value.class
+```
+
+This incorrectly rejected instances of subclasses.
+
+### Solution
+
+The validation was changed to:
+
+```ruby
+value.is_a?(type)
+```
+
+This follows Ruby's inheritance semantics and accepts instances of the declared type and its subclasses.
+
+### Testing
+
+Test coverage was added for:
+
+- direct subclasses
+- multi-level inheritance
+- core Ruby class hierarchies
+
+### Result
+
+LowType now correctly handles subtype relationships during runtime type validation.
+
+---
+
+## PR #35 — Fix repeated `Struct.new` allocation
+
+**[LowType PR #35](https://github.com/low-rb/low_type/pull/35)**
+**Status: Merged**
+
+### Problem
+
+A `Struct.new` definition was being created inside the `config` method.
+
+This caused an anonymous Struct class to be allocated each time the configuration was accessed.
+
+### Solution
+
+The Struct definition was moved out of the method and stored as a constant.
+
+### Result
+
+Repeated calls to `LowType.config` no longer create a new anonymous Struct class, eliminating unnecessary allocation overhead.
+
+---
+
+## PR #39 — Capture class binding using `TracePoint :end`
+
+**[LowType PR #39](https://github.com/low-rb/low_type/pull/39)**
+**Status: Merged**
+
+### Problem
+
+LowType needed access to the binding in which a class body had been evaluated.
+
+Without this context, user-defined constants used by type expressions could result in `NameError`.
+
+### Solution
+
+The class-loading phase was wrapped using `TracePoint :end`.
+
+The implementation captures:
+
+```ruby
+trace.binding
+```
+
+and stores it on:
+
+```ruby
+class_proxy.class_binding
+```
+
+### Result
+
+LowType can retain the original class body binding and use it later when evaluating expressions.
+
+This became a foundational part of user-defined constant resolution.
+
+---
+
+## PR #40 — Add `class_evaluate` to the Evaluator
+
+**[LowType PR #40](https://github.com/low-rb/low_type/pull/40)**
+**Status: Merged**
+
+### Problem
+
+LowType already provided instance-level evaluation, but evaluation in the original class context required a corresponding class-level mechanism.
+
+This caused `NameError` failures when user-defined classes were used in type annotations.
+
+### Solution
+
+Added:
+
+```ruby
+class_evaluate
+```
+
+alongside the existing:
+
+```ruby
+instance_evaluate
+```
+
+The captured `class_binding` is threaded through the evaluator call chain.
+
+### Testing
+
+A specification was added covering custom user-defined class resolution.
+
+### Result
+
+User-defined constants can now be evaluated in the correct original class context.
+
+---
+
+# 6. Main GSoC Deliverable
+
+## PR #45 — Add `rewrite_methods` to `Redefiner`
+
+**[LowType PR #45](https://github.com/low-rb/low_type/pull/45)**
+**Status: Under Review**
+
+This is the primary GSoC deliverable.
+
+The implementation introduces `rewrite_methods` as an alternative to the existing untyped shim approach when runtime type checking is disabled.
+
+---
+
+## 6.1 Configuration Modes
+
+The implementation supports three modes:
+
+```text
+true      → typed methods
+false     → existing untyped shim behavior
+:rewrite  → new method rewriting implementation
+```
+
+This allows the existing behavior to remain available while providing an explicit method-rewriting mode.
+
+---
+
+# 7. How Method Rewriting Works
+
+The rewriting process reconstructs the original method signature without LowType type annotations.
+
+The general flow is:
+
+```text
+Typed method
+     │
+     ▼
+MethodProxy
+     │
+     ▼
+Remove type annotations
+     │
+     ▼
+rewrite_signature
+     │
+     ▼
+Generate normal Ruby method
+     │
+     ▼
+class_eval(method_proxy.export)
+```
+
+The resulting method is evaluated directly in the target class.
+
+This avoids the additional untyped shim layer used by the previous implementation.
+
+---
+
+# 8. Method Visibility
+
+A key requirement was preserving Ruby method visibility.
+
+The rewriting implementation preserves private method visibility rather than unintentionally turning rewritten methods into public methods.
+
+This behavior is explicitly covered by the additional specifications added with PR #45.
+
+---
+
+# 9. Edge-Case Testing
+
+PR #45 adds **13 new edge-case specifications** covering scenarios including:
+
+- private methods
+- positional parameters
+- keyword parameters
+- default values
+- `ValueExpression` unwrapping
+- class methods
+- methods without parameters
+
+These tests verify that method rewriting works across different Ruby method signatures while preserving expected Ruby semantics.
+
+---
+
+# 10. Issues Opened and Resolved
+
+During the project, the following issues were identified and addressed:
+
+| Issue                                               | Description                              | Status / Resolution                             |
+| --------------------------------------------------- | ---------------------------------------- | ----------------------------------------------- |
+| [#28](https://github.com/low-rb/low_type/issues/28) | Subclass type checking bug               | Fixed by PR #29                                 |
+| [#31](https://github.com/low-rb/low_type/issues/31) | `NameError` for user-defined constants   | Fixed by PR #40                                 |
+| [#35](https://github.com/low-rb/low_type/issues/35) | `Struct.new` allocation overhead         | Fixed by PR #35                                 |
+| [#38](https://github.com/low-rb/low_type/issues/38) | Method rewriting / main GSoC deliverable | Implemented in PR #45                           |
+| [#40](https://github.com/low-rb/low_type/issues/40) | Evaluate constants in original binding   | Addressed through class binding/evaluation work |
+
+---
+
+# 11. Performance Evaluation
+
+The new method rewriting implementation was benchmarked against:
+
+1. Plain Ruby
+2. `rewrite_methods`
+3. The existing `untyped_methods` shim
+
+The benchmarks were performed using **Ruby 3.3.0**.
+
+---
+
+## 11.1 Keyword Arguments
+
+Keyword arguments represent the primary use case in which the existing shim implementation introduced significant overhead.
+
+| Approach               | Iterations/sec | Relative Result              |
+| ---------------------- | -------------: | ---------------------------- |
+| Plain Ruby             |      6,200,000 | Baseline                     |
+| `rewrite_methods`      |      5,130,000 | 1.21× slower than plain Ruby |
+| `untyped_methods` shim |      1,100,000 | 5.66× slower than plain Ruby |
+
+The new rewriting implementation therefore achieved approximately:
+
+### **4.67× higher throughput than the existing shim**
+
+This represents a substantial reduction in the overhead associated with the shim approach.
+
+---
+
+## 11.2 Positional Arguments
+
+| Approach               | Iterations/sec | Result                   |
+| ---------------------- | -------------: | ------------------------ |
+| Plain Ruby             |     12,600,000 | Baseline                 |
+| `rewrite_methods`      |     12,490,000 | Statistically equivalent |
+| `untyped_methods` shim |     12,620,000 | Statistically equivalent |
+
+For positional arguments, the rewritten implementation performed at essentially the same level as plain Ruby in the tested benchmark.
+
+---
+
+## 11.3 Object-Reuse Benchmark
+
+The initial keyword-argument benchmark showed a remaining performance gap between rewritten methods and plain Ruby.
+
+Further investigation showed that object allocation inside the benchmark loop contributed to the observed difference.
+
+When the same instance was reused, the results were approximately:
+
+```text
+rewrite_methods: 4.80M i/s
+plain Ruby:      4.80M i/s
+```
+
+Under this configuration, rewritten methods and plain Ruby were statistically identical.
+
+This provides additional evidence that the rewriting mechanism itself does not introduce a significant intrinsic runtime penalty in the tested scenario.
+
+---
+
+# 12. Testing
+
+The reported test suites produced the following results:
+
+| Suite   | Examples | Failures |
+| ------- | -------: | -------: |
+| Lowkey  |       31 |        0 |
+| LowType |      139 |        0 |
+
+### Total
+
+**170 examples — 0 failures**
+
+In addition to the existing test suite, targeted tests were added for the bugs and edge cases encountered during the implementation.
+
+---
+
+# 13. Setup and Reproduction
+
+To clone the repos and run the full test suites:
+
+```bash
+# Lowkey
+git clone https://github.com/low-rb/lowkey
+cd lowkey
+bundle install
+bundle exec rake spec
+
+# LowType
+git clone https://github.com/low-rb/low_type
+cd low_type
+bundle install
+bundle exec rake spec
+```
+
+To run the benchmark:
+
+```bash
+cd low_type
+bundle exec ruby benchmarks/rewriter_benchmark.rb
+```
+
+---
+
+# 14. Documentation
+
+Documentation was updated as part of the method rewriting work.
+
+Updated documentation includes:
+
+- [`README.md`](https://github.com/low-rb/low_type/blob/main/README.md)
+- [`CHANGELOG.md`](https://github.com/low-rb/low_type/blob/main/CHANGELOG.md)
+- [`DEVELOPMENT.md`](https://github.com/low-rb/low_type/blob/main/DEVELOPMENT.md)
+
+These changes document the new behavior and provide context for contributors working with the implementation.
+
+---
+
+# 15. Technical Challenges
+
+## 15.1 Correct Constant Resolution
+
+One of the main challenges was resolving user-defined constants used inside type expressions.
+
+A generic evaluation context was insufficient because Ruby constant lookup depends on the class/module context.
+
+The solution required:
+
+1. Capturing the original class binding.
+2. Storing it in `ClassProxy`.
+3. Passing it through the evaluator.
+4. Adding `class_evaluate`.
+
+This resolved the user-defined constant resolution problem.
+
+---
+
+## 15.2 Reconstructing Ruby Method Signatures
+
+Removing type information from a method signature is more complicated than simply deleting type expressions.
+
+Ruby methods can contain:
+
+- positional arguments
+- keyword arguments
+- default values
+- `ValueExpression` objects
+- class methods
+- methods without parameters
+
+The `ParamProxy#export(typed: false)` and `MethodProxy#rewrite_signature` functionality was therefore required to correctly reconstruct valid Ruby method definitions.
+
+---
+
+## 15.3 Preserving Ruby Semantics
+
+The rewritten method must behave like the original method.
+
+In particular, the implementation needed to preserve:
+
+- method visibility
+- positional arguments
+- keyword arguments
+- default values
+- class methods
+- methods without parameters
+
+This resulted in dedicated edge-case coverage in PR #45.
+
+---
+
+## 15.4 Performance Measurement
+
+The objective was not simply to make the new implementation functional, but to determine whether it actually solved the performance problem.
+
+Benchmarking against both the existing shim and plain Ruby provided a direct comparison.
+
+The results demonstrated a substantial improvement for keyword arguments and near-native performance for the tested positional-argument case.
+
+The object-reuse benchmark also highlighted the importance of controlling allocations when interpreting microbenchmark results.
+
+---
+
+# 16. Current State
+
+## Completed and Merged
+
+The following supporting work has been merged:
+
+### Lowkey
+
+- [PR #6](https://github.com/low-rb/lowkey/pull/6) — `class_binding`
+- [PR #9](https://github.com/low-rb/lowkey/pull/9) — untyped parameter export and signature rewriting
+- [PR #10](https://github.com/low-rb/lowkey/pull/10) — `ValueExpression` unwrapping
+- [PR #11](https://github.com/low-rb/lowkey/pull/11) — `LOWKEY_UNDEFINED` normalization
+
+### LowType
+
+- [PR #29](https://github.com/low-rb/low_type/pull/29) — subclass-aware type validation
+- [PR #35](https://github.com/low-rb/low_type/pull/35) — Struct allocation fix
+- [PR #39](https://github.com/low-rb/low_type/pull/39) — class binding capture
+- [PR #40](https://github.com/low-rb/low_type/pull/40) — class-level constant evaluation
+
+---
+
+## Implemented and Under Review
+
+### [LowType PR #45](https://github.com/low-rb/low_type/pull/45)
+
+The core `rewrite_methods` implementation is complete and includes:
+
+- method signature rewriting
+- untyped parameter export
+- direct `class_eval`
+- configuration modes
+- private method visibility preservation
+- edge-case tests
+- benchmark results
+- documentation updates
+
+The PR is currently under review.
+
+---
+
+# 17. Remaining Work
+
+The following work remains:
+
+## 17.1 Review and Merge PR #45
+
+The primary remaining upstream step is completing review of PR #45 and incorporating any requested changes before merge.
+
+---
+
+## 17.2 Add Explicit `class_method` Metadata
+
+The current implementation uses a regex to detect class methods during signature rewriting. This was suggested by the mentor as a non-blocking improvement. A planned improvement is to add a dedicated `class_method` boolean to `MethodProxy` in Lowkey, which would replace regex-based detection with structured method metadata.
+
+---
+
+## 17.3 End-to-End Testing
+
+The implementation should be tested end-to-end against real Raindeer LowNode files.
+
+This would provide additional validation beyond the focused unit and edge-case specifications.
+
+---
+
+## 17.4 Additional Ruby Edge Cases
+
+Further testing should cover:
+
+- blocks
+- `method_missing` interactions
+- inherited methods
+- prepended methods
+
+These cases can be investigated as the implementation moves toward broader upstream adoption.
+
+---
+
+# 18. Key Outcomes
+
+## 18.1 Method Rewriting Was Implemented
+
+LowType now has a `rewrite_methods` path that removes the need for the additional untyped shim layer.
+
+---
+
+## 18.2 Significant Performance Improvement Over the Existing Shim
+
+For the primary keyword-argument benchmark:
+
+```text
+Existing shim:     1.10M i/s
+Method rewriting:  5.13M i/s
+```
+
+This represents approximately:
+
+**4.67× higher throughput.**
+
+---
+
+## 18.3 Near-Native Performance
+
+The positional-argument benchmark produced:
+
+```text
+Plain Ruby:       12.60M i/s
+rewrite_methods:  12.49M i/s
+```
+
+The results were statistically equivalent in the tested benchmark.
+
+The additional object-reuse keyword benchmark also produced approximately 4.80M i/s for both rewritten methods and plain Ruby.
+
+---
+
+## 18.4 Supporting Infrastructure Was Improved
+
+The project also resolved or improved:
+
+- subclass type validation
+- class binding capture
+- user-defined constant resolution
+- repeated Struct allocation
+- parameter value handling
+- method signature reconstruction
+
+---
+
+# 19. What I Learned
+
+## Ruby Metaprogramming
+
+The project provided substantial experience with Ruby's:
+
+- `class_eval`
+- `TracePoint`
+- `Binding`
+- method definitions
+- method visibility
+- inheritance
+- constant resolution
+
+Understanding the interaction between these mechanisms was essential to implementing method rewriting correctly.
+
+---
+
+## Runtime Performance Analysis
+
+The project reinforced the importance of measuring actual runtime behavior rather than relying only on implementation assumptions.
+
+Benchmarking the existing shim against the rewritten implementation and plain Ruby made the performance impact measurable.
+
+The object-reuse experiment also demonstrated how benchmark design and allocations can influence observed results.
+
+---
+
+## Open Source Development
+
+The project involved:
+
+- breaking work into reviewable PRs
+- identifying and tracking issues
+- writing tests alongside implementation changes
+- responding to implementation problems
+- documenting changes
+- benchmarking proposed improvements
+- iterating toward an upstream-compatible solution
+
+---
+
+## Debugging Through Underlying Behavior
+
+Several issues required investigation beyond the immediate error.
+
+The class-binding and constant-resolution work was particularly valuable in understanding how Ruby's execution context affects metaprogramming and runtime evaluation.
+
+---
+
+# 20. Conclusion
+
+The GSoC 2026 project successfully implemented the core method rewriting approach intended to eliminate the additional untyped shim layer in LowType.
+
+The work produced a new `rewrite_methods` mode, supporting infrastructure in Lowkey and LowType, extensive testing, performance evaluation, and documentation.
+
+The benchmark results demonstrate a substantial performance improvement over the existing shim implementation for keyword arguments while maintaining performance close to plain Ruby.
+
+The supporting changes have been merged, while the primary GSoC deliverable is currently under review in PR #45.
+
+The remaining work consists primarily of completing the upstream review process, performing broader end-to-end validation, and addressing additional Ruby edge cases identified during development.
+
+The implementation provides a foundation for reducing the runtime overhead associated with untyped method shims while preserving Ruby method behavior and enabling future improvements.
+
+---
+
+# 21. Complete Contribution Index
+
+## Lowkey
+
+| PR                                              | Contribution                                       | Status |
+| ----------------------------------------------- | -------------------------------------------------- | ------ |
+| [#6](https://github.com/low-rb/lowkey/pull/6)   | Add `class_binding` to `ClassProxy`                | Merged |
+| [#9](https://github.com/low-rb/lowkey/pull/9)   | Add `export(typed: false)` and `rewrite_signature` | Merged |
+| [#10](https://github.com/low-rb/lowkey/pull/10) | Fix `ValueExpression` unwrapping                   | Merged |
+| [#11](https://github.com/low-rb/lowkey/pull/11) | Normalize `LOWKEY_UNDEFINED`                       | Merged |
+
+## LowType
+
+| PR                                                | Contribution                                  | Status       |
+| ------------------------------------------------- | --------------------------------------------- | ------------ |
+| [#29](https://github.com/low-rb/low_type/pull/29) | Replace strict class equality with `is_a?`    | Merged       |
+| [#35](https://github.com/low-rb/low_type/pull/35) | Fix repeated `Struct.new` allocation          | Merged       |
+| [#39](https://github.com/low-rb/low_type/pull/39) | Capture class binding using `TracePoint :end` | Merged       |
+| [#40](https://github.com/low-rb/low_type/pull/40) | Add `class_evaluate`                          | Merged       |
+| [#45](https://github.com/low-rb/low_type/pull/45) | Add `rewrite_methods` to `Redefiner`          | Under Review |
+
+## Issues
+
+- [Issue #28](https://github.com/low-rb/low_type/issues/28) — Subclass type checking bug
+- [Issue #31](https://github.com/low-rb/low_type/issues/31) — User-defined constant resolution
+- [Issue #35](https://github.com/low-rb/low_type/issues/35) — `Struct.new` allocation overhead
+- [Issue #38](https://github.com/low-rb/low_type/issues/38) — Method rewriting / GSoC deliverable
+- [Issue #40](https://github.com/low-rb/low_type/issues/40) — Original-binding constant evaluation
+
+---
+
+# 22. Final Status
+
+**Project:** Eliminating Shim Methods via Method Rewriting in LowType
+
+**Core implementation:** Implemented
+
+**Supporting infrastructure:** Completed
+
+**Testing:** 170 reported examples, 0 failures
+
+**Performance evaluation:** Completed
+
+**Documentation:** Updated
+
+**Merged upstream:** Supporting Lowkey and LowType contributions listed above
+
+**Primary GSoC deliverable:** [PR #45](https://github.com/low-rb/low_type/pull/45), under review
+
+**Remaining work:** Upstream review/merge, end-to-end validation, and additional edge-case coverage

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :development do
 
   gem 'pry'
   gem 'pry-nav'
+  gem 'ostruct' # required by pry on Ruby 4.0+
+  gem 'benchmark-ips'
   gem 'rack'
   gem 'rack-test'
   gem 'rake', '~> 13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
 PATH
   remote: ../lowkey
   specs:
-    lowkey (0.4.1)
+    lowkey (0.4.3)
       prism
 
 PATH
@@ -27,6 +27,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
+    benchmark-ips (2.15.1)
     coderay (1.1.3)
     diff-lcs (1.6.2)
     json (2.19.3)
@@ -36,6 +37,7 @@ GEM
     method_source (1.1.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
+    ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -103,13 +105,16 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
   x86_64-darwin-22
 
 DEPENDENCIES
+  benchmark-ips
   expressions!
   low_dependency!
   low_type!
   lowkey!
+  ostruct
   pry
   pry-nav
   rack

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ LowType.configure do |config|
   # Set to "false" to disable type checking, which you may like to do in a production environment for example.
   # When disabled, methods are rewritten directly via class_eval to strip type annotations from signatures.
   # Performance is near plain Ruby.
+  # Valid values:
+  #   true     -- type checking on (default)
+  #   false    -- type checking off, untyped shim (define_method + super)
+  #   :rewrite -- type checking off, methods rewritten directly via class_eval
   config.type_checking = true
 
   # Set to :log to log instead of raising of an exception when a type is invalid. [UNRELEASED]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ end
 ## Default values
 
 Place `|` after the type definition to provide a default value when the argument is `nil`:
+
 ```ruby
 def say_hello(greeting = String | 'Hello')
   puts greeting
@@ -25,6 +26,7 @@ end
 ```
 
 Or with keyword arguments:
+
 ```ruby
 def say_hello(greeting: String | 'Hello')
   puts greeting
@@ -34,6 +36,7 @@ end
 ## Enumerables
 
 Wrap your type in an `Array[T]` or `Hash[T]` enumerable type. An `Array` of `String`s looks like:
+
 ```ruby
 def say_hello(greetings: Array[String])
   greetings # => ['Hello', 'Howdy', 'Hey']
@@ -41,6 +44,7 @@ end
 ```
 
 Represent a `Hash` with `key => value` syntax:
+
 ```ruby
 def say_hello(greetings: Hash[String => Integer])
   greetings # => {'Hello' => 123, 'Howdy' => 456, 'Hey' => 789})
@@ -50,6 +54,7 @@ end
 ## Return values
 
 After your method's parameters add `-> { T }` to define a return value:
+
 ```ruby
 def say_hello() -> { String }
   'Hello' # Raises exception if the returned value is not a String.
@@ -57,6 +62,7 @@ end
 ```
 
 Return values can also be defined as `nil`able:
+
 ```ruby
 def say_hello(greetings: Array[String]) -> { String | nil }
   return nil if greetings.first == 'Goodbye'
@@ -65,6 +71,7 @@ end
 ```
 
 If you need a multi-line return type/value then I'll even let you put the `-> { T }` on multiple lines, okay? I won't judge. You are a unique flower 🌸 with your own style, your own needs. You have purpose in this world and though you may never find it, your loved ones will cherish knowing you and wish you were never gone:
+
 ```ruby
 def say_farewell_with_a_long_method_name(farewell: String)
   -> {
@@ -112,6 +119,7 @@ name = 'Tim' # Set the value with type checking
 ### ℹ️ Multiple Arguments
 
 You can define multiple typed accessor methods just like you would with `attr_[reader, writer, accessor]`:
+
 ```ruby
 type_accessor name: String | nil, occupation: 'Doctor', age: Integer | 33
 name # => nil
@@ -124,9 +132,10 @@ age # => 33
 
 ### `type()`
 
-*alias: `low_type()`*
+_alias: `low_type()`_
 
 To define typed `local` variables at runtime use the `type()` method:
+
 ```ruby
 my_var = type MyType | fetch_my_object(id: 123)
 ```
@@ -134,6 +143,7 @@ my_var = type MyType | fetch_my_object(id: 123)
 `my_var` is now type checked to be of type `MyType` when assigned to.
 
 Don't forget that these are just Ruby expressions and you can do more conditional logic as long as the last expression evaluates to a value:
+
 ```ruby
 my_var = type String | (say_goodbye || 'Hello Again')
 ```
@@ -145,6 +155,7 @@ my_var = type String | (say_goodbye || 'Hello Again')
 `Array[T]` and `Hash[T]` class methods represent enumerables in the context of type expressions. If you need to create a new `Array`/`Hash` then use `Array.new()`/`Hash.new()` or Array and Hash literals `[]` and `{}`. This is the same syntax that [RBS](https://github.com/ruby/rbs) uses and we need to get use to these class methods returning type expressions if we're ever going to have inline types in Ruby. [RuboCop](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashConversion) also suggests `{}` over `Hash[]` syntax for creating hashes.
 
 ℹ️ **Note:** To use the `Array[]`/`Hash[]` enumerable syntax with `type()` you must add `using LowType::Syntax` when including LowType:
+
 ```ruby
 include LowType
 using LowType::Syntax
@@ -153,8 +164,9 @@ using LowType::Syntax
 ### `|` Union Types / Default Value
 
 The pipe symbol (`|`) is used in the context of type expressions to define multiple types as well as provide the default value:
+
 - To allow multiple types separate them between pipes: `my_var = TypeOne | TypeTwo`
-- The last *value*/`nil` defined becomes the default value: `my_var = TypeOne | TypeTwo | nil`
+- The last _value_/`nil` defined becomes the default value: `my_var = TypeOne | TypeTwo | nil`
 
 ℹ️ **Note:** If no default value is defined then the argument will be required.
 
@@ -166,24 +178,25 @@ The `-> { T }` syntax is a lambda without an assignment to a local variable. Thi
 
 ### `value(T)` Value Expression
 
-*alias: `low_value()`*
+_alias: `low_value()`_
 
 To treat a type as if it were a value, pass it through `value()` first:
+
 ```ruby
 def my_method(my_arg: String | MyType | value(MyType)) # => MyType is the default value
 ```
 
 ## Performance
 
-LowType evaluates type expressions on *class load* (just once) to be efficient and thread-safe. Then the defined types are checked per method call.  
-However, `type()` type expressions are evaluated when they are called at *runtime* on an instance, and this may impact performance.
+LowType evaluates type expressions on _class load_ (just once) to be efficient and thread-safe. Then the defined types are checked per method call.  
+However, `type()` type expressions are evaluated when they are called at _runtime_ on an instance, and this may impact performance.
 
-|                         | **Evaluation**  | **Validation** | ℹ️ *Example*            |
-|-------------------------|-----------------|----------------|-------------------------|
-| **Method param types**  | 🟢 Class load   | 🟠 Runtime     | `def method(name: T)`   |
-| **Method return types** | 🟢 Class load   | 🟠 Runtime     | `def method() -> { T }` |
-| **Instance types**      | 🟢 Class load   | 🟠 Runtime     | `type_accessor(name: T)`|
-| **Local types**         | 🟠 Runtime      | 🟠 Runtime     | `type(T)`               |
+|                         | **Evaluation** | **Validation** | ℹ️ _Example_             |
+| ----------------------- | -------------- | -------------- | ------------------------ |
+| **Method param types**  | 🟢 Class load  | 🟠 Runtime     | `def method(name: T)`    |
+| **Method return types** | 🟢 Class load  | 🟠 Runtime     | `def method() -> { T }`  |
+| **Instance types**      | 🟢 Class load  | 🟠 Runtime     | `type_accessor(name: T)` |
+| **Local types**         | 🟠 Runtime     | 🟠 Runtime     | `type(T)`                |
 
 ## Scope
 
@@ -197,7 +210,8 @@ Copy and paste the following and change the defaults to configure LowType:
 # This configuration should be set before the class that includes LowType is required.
 LowType.configure do |config|
   # Set to "false" to disable type checking, which you may like to do in a production environment for example.
-  # There will still be a shim method to convert typed args to untyped args but performance will be near 100%.
+  # When disabled, methods are rewritten directly via class_eval to strip type annotations from signatures.
+  # Performance is near plain Ruby.
   config.type_checking = true
 
   # Set to :log to log instead of raising of an exception when a type is invalid. [UNRELEASED]
@@ -266,12 +280,12 @@ class MyApp < Sinatra::Base
 
   # Standard types Sinatra uses.
   get '/' do -> { Array[Integer, Hash, String] }
-    [200, {}, '<h1>Hello!</h1>']    
+    [200, {}, '<h1>Hello!</h1>']
   end
 
   # Specific types for Sinatra.
   get '/' do -> { Tuple[Status, Headers, HTML] }
-    [200, {}, '<h1>Hello!</h1>']    
+    [200, {}, '<h1>Hello!</h1>']
   end
 end
 ```
@@ -279,6 +293,7 @@ end
 ### LowDependency
 
 With [LowDependency](https://github.com/low-rb/low_dependency) you can inject your dependencies automatically via the constructor:
+
 ```ruby
 class MyClass
   include LowType
@@ -314,6 +329,7 @@ Style/RedundantArrayConstructor:
 ## Installation
 
 Add `gem 'low_type'` to your Gemfile then:
+
 ```
 bundle install
 ```
@@ -324,6 +340,7 @@ bundle install
 
 You must `include LowType` in every class that you'd like to have type checking/annotations for.  
 However you can eliminate the need for this `include` in every child class of a parent via the `inherited` hook:
+
 ```ruby
 class Parent
   def self.inherited(child)
@@ -362,6 +379,7 @@ sequenceDiagram
 ```
 
 Three distinct phases isolate concerns:
+
 1. **File Load:** Code is parsed into an Abstract Syntax Tree but not evaluated (see [Lowkey](https://github.com/low-rb/lowkey))
 2. **Class Load:** Constants and expressions are evaluated into real Ruby objects and methods redefined
 3. **Runtime:** Method argument types and return types are optionally validated

--- a/benchmarks/gap_investigation.rb
+++ b/benchmarks/gap_investigation.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Investigates why rewrite_methods is 1.21x slower than plain Ruby.
+# Tests four hypotheses:
+#   1. Object allocation (new instance per call)
+#   2. TracePoint still active during calls
+#   3. class_eval overhead persisting at runtime
+#   4. Method lookup after prepend chain
+
+require 'benchmark/ips'
+require_relative '../lib/low_type'
+
+LowType.configure { |c| c.type_checking = false }
+
+# Plain Ruby -- absolute baseline, no LowType at all
+class PlainBaseline
+  def greet(name: 'World')
+    "Hello, #{name}!"
+  end
+end
+
+# Rewritten via LowType rewrite_methods
+class RewrittenMethod
+  include LowType
+
+  def greet(name: String | value('World'))
+    "Hello, #{name}!"
+  end
+end
+
+# Plain Ruby with same default value as rewritten version
+class PlainWithDefault
+  def greet(name: 'World')
+    "Hello, #{name}!"
+  end
+end
+
+# Check if TracePoint is still active after class load
+tp_count = 0
+TracePoint.trace(:call) { |tp| tp_count += 1 if tp.method_id == :greet }
+
+plain = PlainBaseline.new
+rewritten = RewrittenMethod.new
+
+puts "\n== Hypothesis 1: Is TracePoint still firing during method calls? =="
+tp_count = 0
+10.times { rewritten.greet(name: 'test') }
+puts "TracePoint :call events for rewritten#greet after 10 calls: #{tp_count}"
+tp_count = 0
+10.times { plain.greet(name: 'test') }
+puts "TracePoint :call events for plain#greet after 10 calls: #{tp_count}"
+TracePoint.trace(:call).disable rescue nil
+
+puts "\n== Hypothesis 2: Prepend chain depth =="
+puts "RewrittenMethod ancestors: #{RewrittenMethod.ancestors.first(5).inspect}"
+puts "PlainBaseline ancestors:   #{PlainBaseline.ancestors.first(5).inspect}"
+
+puts "\n== Hypothesis 3: Method defined where? =="
+puts "RewrittenMethod#greet defined in: #{RewrittenMethod.instance_method(:greet).owner}"
+puts "PlainBaseline#greet defined in:   #{PlainBaseline.instance_method(:greet).owner}"
+
+puts "\n== Benchmark: Plain vs Rewritten (no object allocation) =="
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report('plain baseline')   { plain.greet(name: 'World') }
+  x.report('rewritten')        { rewritten.greet(name: 'World') }
+
+  x.compare!
+end
+
+puts "\n== Benchmark: With object allocation (new each time) =="
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report('plain baseline')   { PlainBaseline.new.greet(name: 'World') }
+  x.report('rewritten')        { RewrittenMethod.new.greet(name: 'World') }
+
+  x.compare!
+end

--- a/benchmarks/rewriter_benchmark.rb
+++ b/benchmarks/rewriter_benchmark.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# Benchmark: Plain Ruby vs untyped_methods shim vs rewrite_methods
+#
+# Compares three execution paths for calling a typed LowType method
+# when type_checking is disabled:
+#
+#   1. Plain Ruby       -- baseline, no LowType involvement
+#   2. Shim (old)       -- untyped_methods: define_method + super dispatch
+#   3. Rewriter (new)   -- rewrite_methods: class_eval direct redefinition
+
+require 'benchmark/ips'
+require_relative '../lib/low_type'
+
+# ---------------------------------------------------------------------------
+# 1. Plain Ruby baseline -- no LowType, no overhead
+# ---------------------------------------------------------------------------
+class PlainKeyword
+  def greet(name:, greeting: 'Hello')
+    "#{greeting}, #{name}!"
+  end
+end
+
+class PlainPositional
+  def add(a, b = 0)
+    a + b
+  end
+end
+
+# ---------------------------------------------------------------------------
+# 2. Shim (untyped_methods) -- old code path
+#    type_checking: false routes to untyped_methods which uses define_method
+#    + Lowkey re-lookup + super on every call
+# ---------------------------------------------------------------------------
+LowType.configure { |c| c.type_checking = false }
+
+# Force shim path by temporarily pointing redefine to untyped_methods.
+# We do this by reopening Redefiner and aliasing before the rewriter existed.
+module Low
+  class Redefiner
+    class << self
+      def redefine_shim(method_proxies:, class_proxy:, klass: nil)
+        untyped_methods(method_proxies:, class_proxy:)
+      end
+    end
+  end
+end
+
+# Patch LowType to use shim path
+module LowType
+  def self.included_shim(klass)
+    file_path = Low::FileQuery.file_path(klass:)
+    file_proxy = Lowkey.load(file_path, cache: false)
+    class_proxy = file_proxy[klass.name]
+
+    klass.include Low::ExpressionHelpers
+    klass.extend Low::ExpressionHelpers
+    klass.extend Low::TypeAccessors
+    klass.extend Low::Types
+
+    tp = TracePoint.new(:end) do |trace|
+      next unless trace.self == klass
+
+      class_proxy.class_binding = trace.binding
+      Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods, class_binding: class_proxy.class_binding)
+
+      result = Low::Redefiner.redefine_shim(method_proxies: class_proxy.instance_methods, class_proxy:, klass:)
+      klass.prepend result if result
+
+      tp.disable
+    end
+    tp.enable
+  end
+end
+
+# Load shim fixtures by including via included_shim
+class ShimKeyword
+  def greet(name: String, greeting: String | value('Hello'))
+    "#{greeting}, #{name}!"
+  end
+end
+LowType.included_shim(ShimKeyword)
+
+class ShimPositional
+  def add(a = Integer, b = Integer | value(0))
+    a + b
+  end
+end
+LowType.included_shim(ShimPositional)
+
+# ---------------------------------------------------------------------------
+# 3. Rewriter (rewrite_methods) -- new code path via class_eval
+# ---------------------------------------------------------------------------
+class RewriteKeyword
+  include LowType
+
+  def greet(name: String, greeting: String | value('Hello'))
+    "#{greeting}, #{name}!"
+  end
+end
+
+class RewritePositional
+  include LowType
+
+  def add(a = Integer, b = Integer | value(0))
+    a + b
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Run benchmarks
+# ---------------------------------------------------------------------------
+puts "\n== Keyword args benchmark =="
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report('plain ruby')    { PlainKeyword.new.greet(name: 'World') }
+  x.report('shim (old)')    { ShimKeyword.new.greet(name: 'World') }
+  x.report('rewriter (new)') { RewriteKeyword.new.greet(name: 'World') }
+
+  x.compare!
+end
+
+puts "\n== Positional args benchmark =="
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report('plain ruby')    { PlainPositional.new.add(1, 2) }
+  x.report('shim (old)')    { ShimPositional.new.add(1, 2) }
+  x.report('rewriter (new)') { RewritePositional.new.add(1, 2) }
+
+  x.compare!
+end

--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -62,6 +62,8 @@ module Low
             klass.send(:private, method_proxy.name)
           end
         end
+
+        nil
       end
 
       def typed_methods(method_proxies:, class_proxy:) # rubocop:disable Metrics

--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -26,12 +26,14 @@ module Low
   #      │              │                 │                 │               │
   class Redefiner
     class << self
-      # TODO: Pass in "klass" and use it to class_eval/eval methods in the binding of the class that included LowType.
       def redefine(method_proxies:, class_proxy:, klass: nil)
-        if LowType.config.type_checking
+        case LowType.config.type_checking
+        when true
           typed_methods(method_proxies:, class_proxy:)
-        else
+        when :rewrite
           rewrite_methods(method_proxies:, class_proxy:, klass:)
+        else
+          untyped_methods(method_proxies:, class_proxy:)
         end
       end
 

--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -27,11 +27,11 @@ module Low
   class Redefiner
     class << self
       # TODO: Pass in "klass" and use it to class_eval/eval methods in the binding of the class that included LowType.
-      def redefine(method_proxies:, class_proxy:)
+      def redefine(method_proxies:, class_proxy:, klass: nil)
         if LowType.config.type_checking
           typed_methods(method_proxies:, class_proxy:)
         else
-          untyped_methods(method_proxies:, class_proxy:)
+          rewrite_methods(method_proxies:, class_proxy:, klass:)
         end
       end
 
@@ -51,6 +51,18 @@ module Low
       end
 
       private
+
+      def rewrite_methods(method_proxies:, class_proxy:, klass:)
+        method_proxies.values.filter(&:expressions?).each do |method_proxy|
+          method_proxy.rewrite_signature
+
+          klass.class_eval(method_proxy.export, method_proxy.file_path, method_proxy.start_line)
+
+          if class_proxy.private_start_line && method_proxy.start_line > class_proxy.private_start_line
+            klass.send(:private, method_proxy.name)
+          end
+        end
+      end
 
       def typed_methods(method_proxies:, class_proxy:) # rubocop:disable Metrics
         Module.new do

--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -52,8 +52,11 @@ module LowType
 
       Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods, class_binding: class_proxy.class_binding)
 
-      klass.prepend Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:)
-      klass.singleton_class.prepend Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:)
+      result = Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:, klass:)
+      klass.prepend result if result
+
+      singleton_result = Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:, klass: klass.singleton_class)
+      klass.singleton_class.prepend singleton_result if singleton_result
 
       Low::Adapter::Loader.load(klass:, class_proxy:)
 

--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -53,10 +53,10 @@ module LowType
       Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods, class_binding: class_proxy.class_binding)
 
       result = Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:, klass:)
-      klass.prepend result if result
+      klass.prepend result if result.is_a?(Module)
 
       singleton_result = Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:, klass: klass.singleton_class)
-      klass.singleton_class.prepend singleton_result if singleton_result
+      klass.singleton_class.prepend singleton_result if singleton_result.is_a?(Module)
 
       Low::Adapter::Loader.load(klass:, class_proxy:)
 

--- a/spec/features/rewriter_spec.rb
+++ b/spec/features/rewriter_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../fixtures/rewriter'
+
+RSpec.describe 'rewrite_methods (type_checking: false)' do
+  subject(:instance) { RewriterFixture.new }
+
+  # -------------------------------------------------------------------------
+  # Required positional
+  # -------------------------------------------------------------------------
+  describe '#positional_required' do
+    it 'accepts a correct-type argument' do
+      expect(instance.positional_required('Alice')).to eq('Alice')
+    end
+
+    it 'accepts a wrong-type argument without raising' do
+      expect { instance.positional_required(42) }.not_to raise_error
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Optional positional with ValueExpression default
+  # -------------------------------------------------------------------------
+  describe '#positional_with_default' do
+    it 'returns the passed value' do
+      expect(instance.positional_with_default(5)).to eq(5)
+    end
+
+    it 'uses the unwrapped default value when no arg given' do
+      expect(instance.positional_with_default).to eq(0)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Required keyword
+  # -------------------------------------------------------------------------
+  describe '#keyword_required' do
+    it 'accepts a correct-type keyword argument' do
+      expect(instance.keyword_required(name: 'Bob')).to eq('Bob')
+    end
+
+    it 'accepts a wrong-type keyword argument without raising' do
+      expect { instance.keyword_required(name: 123) }.not_to raise_error
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Optional keyword with ValueExpression default
+  # -------------------------------------------------------------------------
+  describe '#keyword_with_default' do
+    it 'returns the passed keyword value' do
+      expect(instance.keyword_with_default(greeting: 'Hi')).to eq('Hi')
+    end
+
+    it 'uses the unwrapped default value when no kwarg given' do
+      expect(instance.keyword_with_default).to eq('Hello')
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # No params
+  # -------------------------------------------------------------------------
+  describe '#no_params' do
+    it 'works correctly with no arguments' do
+      expect(instance.no_params).to eq('ok')
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Class method
+  # -------------------------------------------------------------------------
+  describe '.class_method' do
+    it 'rewrites and calls the class method correctly' do
+      expect(RewriterFixture.class_method('MyLabel')).to eq('MyLabel')
+    end
+
+    it 'accepts wrong-type argument without raising' do
+      expect { RewriterFixture.class_method(99) }.not_to raise_error
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Private method visibility preserved
+  # -------------------------------------------------------------------------
+  describe '#private_method' do
+    it 'remains private after rewrite' do
+      expect { instance.private_method('secret') }.to raise_error(NoMethodError)
+    end
+
+    it 'is still callable internally' do
+      expect(instance.send(:private_method, 'secret')).to eq('secret')
+    end
+  end
+end

--- a/spec/features/rewriter_spec.rb
+++ b/spec/features/rewriter_spec.rb
@@ -2,8 +2,10 @@
 
 require_relative '../fixtures/rewriter'
 
-RSpec.describe 'rewrite_methods (type_checking: false)' do
+RSpec.describe 'rewrite_methods (type_checking: :rewrite)' do
   subject(:instance) { RewriterFixture.new }
+
+  after(:all) { LowType.configure { |c| c.type_checking = true } }
 
   # -------------------------------------------------------------------------
   # Required positional

--- a/spec/features/type_checking_spec.rb
+++ b/spec/features/type_checking_spec.rb
@@ -3,11 +3,42 @@
 require_relative '../../lib/low_type'
 
 RSpec.describe 'LowType.config.type_checking' do
-  context 'when type checking is disabled' do
+  context 'when type_checking: true (typed methods)' do
+    subject(:type_checking) { TypeCheckingEnabled.new }
+
+    before(:all) do
+      LowType.configure { |config| config.type_checking = true }
+      require_relative '../fixtures/type_checking_enabled'
+    end
+
+    describe '#typed_arg' do
+      it 'passes through the argument' do
+        expect(type_checking.typed_arg('Hi')).to eq('Hi')
+      end
+
+      context 'when arg is correct type' do
+        it 'accepts the typed arg' do
+          expect { type_checking.typed_arg('Yo') }.not_to raise_error
+        end
+      end
+
+      context 'when arg is wrong type' do
+        it 'raises an argument type error' do
+          expect { type_checking.typed_arg(123) }.to raise_error(Low::ArgumentTypeError)
+        end
+      end
+    end
+  end
+
+  context 'when type_checking: false (untyped shim)' do
     subject(:type_checking) { TypeCheckingDisabled.new }
 
-    LowType.configure { |config| config.type_checking = false }
-    require_relative '../fixtures/type_checking_disabled'
+    before(:all) do
+      LowType.configure { |config| config.type_checking = false }
+      require_relative '../fixtures/type_checking_disabled'
+    end
+
+    after(:all) { LowType.configure { |config| config.type_checking = true } }
 
     describe '#typed_arg' do
       it 'passes through the argument' do
@@ -28,11 +59,15 @@ RSpec.describe 'LowType.config.type_checking' do
     end
   end
 
-  context 'when type checking is enabled' do
-    subject(:type_checking) { TypeCheckingEnabled.new }
+  context 'when type_checking: :rewrite (rewrite_methods)' do
+    subject(:type_checking) { TypeCheckingRewrite.new }
 
-    LowType.configure { |config| config.type_checking = true }
-    require_relative '../fixtures/type_checking_enabled'
+    before(:all) do
+      LowType.configure { |config| config.type_checking = :rewrite }
+      require_relative '../fixtures/type_checking_rewrite'
+    end
+
+    after(:all) { LowType.configure { |config| config.type_checking = true } }
 
     describe '#typed_arg' do
       it 'passes through the argument' do
@@ -46,8 +81,14 @@ RSpec.describe 'LowType.config.type_checking' do
       end
 
       context 'when arg is wrong type' do
-        it 'raises an argument type error' do
-          expect { type_checking.typed_arg(123) }.to raise_error(Low::ArgumentTypeError)
+        it 'accepts the wrongly typed arg without raising' do
+          expect { type_checking.typed_arg(123) }.not_to raise_error
+        end
+      end
+
+      context 'when no arg provided' do
+        it 'raises ArgumentError since no default value is defined' do
+          expect { type_checking.typed_arg }.to raise_error(ArgumentError)
         end
       end
     end

--- a/spec/fixtures/rewriter.rb
+++ b/spec/fixtures/rewriter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+
+LowType.configure { |c| c.type_checking = false }
+
+class RewriterFixture
+  include LowType
+
+  # Required positional
+  def positional_required(name = String)
+    name
+  end
+
+  # Optional positional with default value
+  def positional_with_default(count = Integer | value(0))
+    count
+  end
+
+  # Required keyword
+  def keyword_required(name: String)
+    name
+  end
+
+  # Optional keyword with default value
+  def keyword_with_default(greeting: String | value('Hello'))
+    greeting
+  end
+
+  # No params
+  def no_params
+    'ok'
+  end
+
+  # Class method
+  def self.class_method(label = String)
+    label
+  end
+
+  private
+
+  # Private method
+  def private_method(secret = String)
+    secret
+  end
+end

--- a/spec/fixtures/rewriter.rb
+++ b/spec/fixtures/rewriter.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../lib/low_type'
 
-LowType.configure { |c| c.type_checking = false }
+LowType.configure { |c| c.type_checking = :rewrite }
 
 class RewriterFixture
   include LowType
@@ -44,3 +44,5 @@ class RewriterFixture
     secret
   end
 end
+
+LowType.configure { |c| c.type_checking = true }

--- a/spec/fixtures/type_checking_rewrite.rb
+++ b/spec/fixtures/type_checking_rewrite.rb
@@ -2,9 +2,9 @@
 
 require_relative '../../lib/low_type'
 
-LowType.configure { |c| c.type_checking = false }
+LowType.configure { |c| c.type_checking = :rewrite }
 
-class TypeCheckingDisabled
+class TypeCheckingRewrite
   include LowType
 
   def typed_arg(greeting = String)

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -19,4 +19,7 @@ RSpec.configure do |config|
     # Large diff when expected objects don't match.
     expectations.max_formatted_output_length = 10_000
   end
+
+  # Reset type_checking to true after each example to prevent config leaking between specs
+  config.after(:each) { LowType.configure { |c| c.type_checking = true } }
 end


### PR DESCRIPTION
## Summary
Implements `rewrite_methods` in `Low::Redefiner` as the new code path when 
`LowType.config.type_checking` is `false`. Foundational piece for low-rb/low_type#38.

## Changes

**`lib/definitions/redefiner.rb`**
- Added `rewrite_methods` - calls `method_proxy.rewrite_signature` to strip type 
  annotations from the shared lines array, then uses `klass.class_eval(method_proxy.export)` 
  to redefine the method directly on the class
- Preserves `private` visibility for methods below `private_start_line`
- `redefine` now accepts optional `klass:` keyword and routes to `rewrite_methods` 
  when type checking is off

**`lib/low_type.rb`**
- Both `redefine` calls now pass `klass:` through
- Result guarded with `if result` since `rewrite_methods` returns `nil`, not a Module

## Depends on
- low-rb/lowkey#9 (`ParamProxy#export(typed: false)` and `MethodProxy#rewrite_signature`)

## Tests
122 examples, 0 failures

## Report

<details>
  <summary>
  Google Summer of Code 2026 — Final Work Report
  </summary>

# Google Summer of Code 2026 — Final Work Report

## Eliminating Shim Methods via Method Rewriting in LowType

**Contributor:** Aditya Chauhan
**Organization:** Ruby
**Mentor:** Maedi
**Program:** Google Summer of Code 2026

---

## 1. Project Overview

The goal of this project was to improve the runtime performance and implementation of method handling in [LowType](https://github.com/low-rb/low_type) by eliminating the need for untyped shim methods when runtime type checking is disabled.

LowType introduces runtime type expressions into Ruby method definitions. When type checking is disabled, the existing implementation uses untyped shim methods. Although this preserves the desired behavior, the additional shim layer can introduce unnecessary runtime overhead.

The primary objective of this project was therefore to implement a method rewriting approach that removes the type annotations from the original method definition and evaluates the resulting Ruby method directly in the target class.

The project required supporting changes in both LowType and its companion [Lowkey](https://github.com/low-rb/lowkey) library. These changes addressed method signature reconstruction, parameter handling, class bindings, constant resolution, type validation, and related performance issues.

---

# 2. Project Goals

The main goals of the GSoC project were:

1. Investigate the existing untyped shim implementation and its performance characteristics.
2. Design and implement a method rewriting mechanism.
3. Replace untyped shim methods with rewritten methods when type checking is disabled.
4. Preserve Ruby method behavior and visibility during rewriting.
5. Correctly resolve user-defined constants used in type expressions.
6. Capture and preserve the appropriate class binding during class loading.
7. Add the supporting functionality required in Lowkey and LowType.
8. Add comprehensive tests for normal and edge-case method signatures.
9. Benchmark the new implementation against the existing shim implementation and plain Ruby.
10. Document the implementation and its configuration.

---

# 3. Summary of Accomplishments

The project resulted in the following major contributions:

- Added class-binding support to Lowkey's `ClassProxy`.
- Added untyped parameter export support to `ParamProxy`.
- Added method signature rewriting support to `MethodProxy`.
- Fixed `ValueExpression` handling during untyped parameter export.
- Normalized `LOWKEY_UNDEFINED` handling.
- Fixed subclass type validation in LowType.
- Removed repeated `Struct.new` allocation from configuration access.
- Added class-binding capture using `TracePoint :end`.
- Added class-level constant evaluation to the evaluator.
- Implemented `rewrite_methods` in LowType's `Redefiner`.
- Added support for typed, untyped, and rewrite configuration modes.
- Preserved private method visibility during rewriting.
- Added 13 edge-case specifications for the rewriting implementation.
- Benchmarked rewritten methods against the existing shim implementation and plain Ruby.
- Updated project documentation.

The supporting changes have been merged according to the current project audit. The primary GSoC deliverable, `rewrite_methods`, is implemented in [LowType PR #45](https://github.com/low-rb/low_type/pull/45) and is currently under review.

---

# 4. Contributions to Lowkey

The method rewriting implementation required several changes to Lowkey.

## PR #6 — Add `class_binding` to `ClassProxy`

**[Lowkey PR #6](https://github.com/low-rb/lowkey/pull/6)**
**Status: Merged**

Added `class_binding` as an `attr_accessor` to `ClassProxy`, initialized to `nil`.

This allows LowType to retain the binding associated with the class body after the class has been loaded.

The captured class binding is required for correctly evaluating user-defined constants in the context in which the class was originally defined.

### Why this was needed

Ruby constant resolution depends on the surrounding class/module context. A generic evaluation context is therefore insufficient for all type-expression cases.

Storing the original class binding provides LowType with the correct context for later evaluation.

---

## PR #9 — Add `export(typed: false)` and `rewrite_signature`

**[Lowkey PR #9](https://github.com/low-rb/lowkey/pull/9)**
**Status: Merged**

Added:

```ruby
ParamProxy#export(typed: false)
```

This allows a parameter to be exported without its LowType type annotation.

The PR also added:

```ruby
MethodProxy#rewrite_signature
```

This reconstructs a method signature using untyped parameter exports and replaces the appropriate signature line in the shared source representation.

### Purpose

This functionality forms the foundation of method rewriting by allowing LowType's type information to be removed while retaining the original Ruby method signature.

---

## PR #10 — Fix `ValueExpression` unwrapping

**[Lowkey PR #10](https://github.com/low-rb/lowkey/pull/10)**
**Status: Merged**

Fixed handling of `ValueExpression` objects during:

```ruby
ParamProxy#export(typed: false)
```

The implementation uses:

```ruby
defined?(ValueExpression) ? ValueExpression : nil
```

to safely check if `ValueExpression` is loaded, then uses `instance_of?` for the actual check. This avoids a `NameError` when LowType is not loaded in Lowkey's context.

Two specifications were added covering:

- positional parameters
- keyword parameters

This ensures that default values represented by `ValueExpression` are correctly unwrapped when generating rewritten method signatures.

---

## PR #11 — Normalize `LOWKEY_UNDEFINED`

**[Lowkey PR #11](https://github.com/low-rb/lowkey/pull/11)**
**Status: Merged**

Fixed `proxy_factory.rb` assigning:

```ruby
':LOWKEY_UNDEFINED'
```

as a string instead of:

```ruby
:LOWKEY_UNDEFINED
```

as a symbol.

The corresponding guards in `param_proxy.rb` were simplified by removing support for both representations in:

- `required?`
- `resolved_default`

This normalized the internal representation and simplified the surrounding implementation.

---

# 5. Contributions to LowType

## PR #29 — Replace strict class equality with `is_a?`

**[LowType PR #29](https://github.com/low-rb/low_type/pull/29)**
**Status: Merged**

### Problem

Type validation used strict class equality:

```ruby
type == value.class
```

This incorrectly rejected instances of subclasses.

### Solution

The validation was changed to:

```ruby
value.is_a?(type)
```

This follows Ruby's inheritance semantics and accepts instances of the declared type and its subclasses.

### Testing

Test coverage was added for:

- direct subclasses
- multi-level inheritance
- core Ruby class hierarchies

### Result

LowType now correctly handles subtype relationships during runtime type validation.

---

## PR #35 — Fix repeated `Struct.new` allocation

**[LowType PR #35](https://github.com/low-rb/low_type/pull/35)**
**Status: Merged**

### Problem

A `Struct.new` definition was being created inside the `config` method.

This caused an anonymous Struct class to be allocated each time the configuration was accessed.

### Solution

The Struct definition was moved out of the method and stored as a constant.

### Result

Repeated calls to `LowType.config` no longer create a new anonymous Struct class, eliminating unnecessary allocation overhead.

---

## PR #39 — Capture class binding using `TracePoint :end`

**[LowType PR #39](https://github.com/low-rb/low_type/pull/39)**
**Status: Merged**

### Problem

LowType needed access to the binding in which a class body had been evaluated.

Without this context, user-defined constants used by type expressions could result in `NameError`.

### Solution

The class-loading phase was wrapped using `TracePoint :end`.

The implementation captures:

```ruby
trace.binding
```

and stores it on:

```ruby
class_proxy.class_binding
```

### Result

LowType can retain the original class body binding and use it later when evaluating expressions.

This became a foundational part of user-defined constant resolution.

---

## PR #40 — Add `class_evaluate` to the Evaluator

**[LowType PR #40](https://github.com/low-rb/low_type/pull/40)**
**Status: Merged**

### Problem

LowType already provided instance-level evaluation, but evaluation in the original class context required a corresponding class-level mechanism.

This caused `NameError` failures when user-defined classes were used in type annotations.

### Solution

Added:

```ruby
class_evaluate
```

alongside the existing:

```ruby
instance_evaluate
```

The captured `class_binding` is threaded through the evaluator call chain.

### Testing

A specification was added covering custom user-defined class resolution.

### Result

User-defined constants can now be evaluated in the correct original class context.

---

# 6. Main GSoC Deliverable

## PR #45 — Add `rewrite_methods` to `Redefiner`

**[LowType PR #45](https://github.com/low-rb/low_type/pull/45)**
**Status: Under Review**

This is the primary GSoC deliverable.

The implementation introduces `rewrite_methods` as an alternative to the existing untyped shim approach when runtime type checking is disabled.

---

## 6.1 Configuration Modes

The implementation supports three modes:

```text
true      → typed methods
false     → existing untyped shim behavior
:rewrite  → new method rewriting implementation
```

This allows the existing behavior to remain available while providing an explicit method-rewriting mode.

---

# 7. How Method Rewriting Works

The rewriting process reconstructs the original method signature without LowType type annotations.

The general flow is:

```text
Typed method
     │
     ▼
MethodProxy
     │
     ▼
Remove type annotations
     │
     ▼
rewrite_signature
     │
     ▼
Generate normal Ruby method
     │
     ▼
class_eval(method_proxy.export)
```

The resulting method is evaluated directly in the target class.

This avoids the additional untyped shim layer used by the previous implementation.

---

# 8. Method Visibility

A key requirement was preserving Ruby method visibility.

The rewriting implementation preserves private method visibility rather than unintentionally turning rewritten methods into public methods.

This behavior is explicitly covered by the additional specifications added with PR #45.

---

# 9. Edge-Case Testing

PR #45 adds **13 new edge-case specifications** covering scenarios including:

- private methods
- positional parameters
- keyword parameters
- default values
- `ValueExpression` unwrapping
- class methods
- methods without parameters

These tests verify that method rewriting works across different Ruby method signatures while preserving expected Ruby semantics.

---

# 10. Issues Opened and Resolved

During the project, the following issues were identified and addressed:

| Issue                                               | Description                              | Status / Resolution                             |
| --------------------------------------------------- | ---------------------------------------- | ----------------------------------------------- |
| [#28](https://github.com/low-rb/low_type/issues/28) | Subclass type checking bug               | Fixed by PR #29                                 |
| [#31](https://github.com/low-rb/low_type/issues/31) | `NameError` for user-defined constants   | Fixed by PR #40                                 |
| [#35](https://github.com/low-rb/low_type/issues/35) | `Struct.new` allocation overhead         | Fixed by PR #35                                 |
| [#38](https://github.com/low-rb/low_type/issues/38) | Method rewriting / main GSoC deliverable | Implemented in PR #45                           |
| [#40](https://github.com/low-rb/low_type/issues/40) | Evaluate constants in original binding   | Addressed through class binding/evaluation work |

---

# 11. Performance Evaluation

The new method rewriting implementation was benchmarked against:

1. Plain Ruby
2. `rewrite_methods`
3. The existing `untyped_methods` shim

The benchmarks were performed using **Ruby 3.3.0**.

---

## 11.1 Keyword Arguments

Keyword arguments represent the primary use case in which the existing shim implementation introduced significant overhead.

| Approach               | Iterations/sec | Relative Result              |
| ---------------------- | -------------: | ---------------------------- |
| Plain Ruby             |      6,200,000 | Baseline                     |
| `rewrite_methods`      |      5,130,000 | 1.21× slower than plain Ruby |
| `untyped_methods` shim |      1,100,000 | 5.66× slower than plain Ruby |

The new rewriting implementation therefore achieved approximately:

### **4.67× higher throughput than the existing shim**

This represents a substantial reduction in the overhead associated with the shim approach.

---

## 11.2 Positional Arguments

| Approach               | Iterations/sec | Result                   |
| ---------------------- | -------------: | ------------------------ |
| Plain Ruby             |     12,600,000 | Baseline                 |
| `rewrite_methods`      |     12,490,000 | Statistically equivalent |
| `untyped_methods` shim |     12,620,000 | Statistically equivalent |

For positional arguments, the rewritten implementation performed at essentially the same level as plain Ruby in the tested benchmark.

---

## 11.3 Object-Reuse Benchmark

The initial keyword-argument benchmark showed a remaining performance gap between rewritten methods and plain Ruby.

Further investigation showed that object allocation inside the benchmark loop contributed to the observed difference.

When the same instance was reused, the results were approximately:

```text
rewrite_methods: 4.80M i/s
plain Ruby:      4.80M i/s
```

Under this configuration, rewritten methods and plain Ruby were statistically identical.

This provides additional evidence that the rewriting mechanism itself does not introduce a significant intrinsic runtime penalty in the tested scenario.

---

# 12. Testing

The reported test suites produced the following results:

| Suite   | Examples | Failures |
| ------- | -------: | -------: |
| Lowkey  |       31 |        0 |
| LowType |      139 |        0 |

### Total

**170 examples — 0 failures**

In addition to the existing test suite, targeted tests were added for the bugs and edge cases encountered during the implementation.

---

# 13. Setup and Reproduction

To clone the repos and run the full test suites:

```bash
# Lowkey
git clone https://github.com/low-rb/lowkey
cd lowkey
bundle install
bundle exec rake spec

# LowType
git clone https://github.com/low-rb/low_type
cd low_type
bundle install
bundle exec rake spec
```

To run the benchmark:

```bash
cd low_type
bundle exec ruby benchmarks/rewriter_benchmark.rb
```

---

# 14. Documentation

Documentation was updated as part of the method rewriting work.

Updated documentation includes:

- [`README.md`](https://github.com/low-rb/low_type/blob/main/README.md)
- [`CHANGELOG.md`](https://github.com/low-rb/low_type/blob/main/CHANGELOG.md)
- [`DEVELOPMENT.md`](https://github.com/low-rb/low_type/blob/main/DEVELOPMENT.md)

These changes document the new behavior and provide context for contributors working with the implementation.

---

# 15. Technical Challenges

## 15.1 Correct Constant Resolution

One of the main challenges was resolving user-defined constants used inside type expressions.

A generic evaluation context was insufficient because Ruby constant lookup depends on the class/module context.

The solution required:

1. Capturing the original class binding.
2. Storing it in `ClassProxy`.
3. Passing it through the evaluator.
4. Adding `class_evaluate`.

This resolved the user-defined constant resolution problem.

---

## 15.2 Reconstructing Ruby Method Signatures

Removing type information from a method signature is more complicated than simply deleting type expressions.

Ruby methods can contain:

- positional arguments
- keyword arguments
- default values
- `ValueExpression` objects
- class methods
- methods without parameters

The `ParamProxy#export(typed: false)` and `MethodProxy#rewrite_signature` functionality was therefore required to correctly reconstruct valid Ruby method definitions.

---

## 15.3 Preserving Ruby Semantics

The rewritten method must behave like the original method.

In particular, the implementation needed to preserve:

- method visibility
- positional arguments
- keyword arguments
- default values
- class methods
- methods without parameters

This resulted in dedicated edge-case coverage in PR #45.

---

## 15.4 Performance Measurement

The objective was not simply to make the new implementation functional, but to determine whether it actually solved the performance problem.

Benchmarking against both the existing shim and plain Ruby provided a direct comparison.

The results demonstrated a substantial improvement for keyword arguments and near-native performance for the tested positional-argument case.

The object-reuse benchmark also highlighted the importance of controlling allocations when interpreting microbenchmark results.

---

# 16. Current State

## Completed and Merged

The following supporting work has been merged:

### Lowkey

- [PR #6](https://github.com/low-rb/lowkey/pull/6) — `class_binding`
- [PR #9](https://github.com/low-rb/lowkey/pull/9) — untyped parameter export and signature rewriting
- [PR #10](https://github.com/low-rb/lowkey/pull/10) — `ValueExpression` unwrapping
- [PR #11](https://github.com/low-rb/lowkey/pull/11) — `LOWKEY_UNDEFINED` normalization

### LowType

- [PR #29](https://github.com/low-rb/low_type/pull/29) — subclass-aware type validation
- [PR #35](https://github.com/low-rb/low_type/pull/35) — Struct allocation fix
- [PR #39](https://github.com/low-rb/low_type/pull/39) — class binding capture
- [PR #40](https://github.com/low-rb/low_type/pull/40) — class-level constant evaluation

---

## Implemented and Under Review

### [LowType PR #45](https://github.com/low-rb/low_type/pull/45)

The core `rewrite_methods` implementation is complete and includes:

- method signature rewriting
- untyped parameter export
- direct `class_eval`
- configuration modes
- private method visibility preservation
- edge-case tests
- benchmark results
- documentation updates

The PR is currently under review.

---

# 17. Remaining Work

The following work remains:

## 17.1 Review and Merge PR #45

The primary remaining upstream step is completing review of PR #45 and incorporating any requested changes before merge.

---

## 17.2 Add Explicit `class_method` Metadata

The current implementation uses a regex to detect class methods during signature rewriting. This was suggested by the mentor as a non-blocking improvement. A planned improvement is to add a dedicated `class_method` boolean to `MethodProxy` in Lowkey, which would replace regex-based detection with structured method metadata.

---

## 17.3 End-to-End Testing

The implementation should be tested end-to-end against real Raindeer LowNode files.

This would provide additional validation beyond the focused unit and edge-case specifications.

---

## 17.4 Additional Ruby Edge Cases

Further testing should cover:

- blocks
- `method_missing` interactions
- inherited methods
- prepended methods

These cases can be investigated as the implementation moves toward broader upstream adoption.

---

# 18. Key Outcomes

## 18.1 Method Rewriting Was Implemented

LowType now has a `rewrite_methods` path that removes the need for the additional untyped shim layer.

---

## 18.2 Significant Performance Improvement Over the Existing Shim

For the primary keyword-argument benchmark:

```text
Existing shim:     1.10M i/s
Method rewriting:  5.13M i/s
```

This represents approximately:

**4.67× higher throughput.**

---

## 18.3 Near-Native Performance

The positional-argument benchmark produced:

```text
Plain Ruby:       12.60M i/s
rewrite_methods:  12.49M i/s
```

The results were statistically equivalent in the tested benchmark.

The additional object-reuse keyword benchmark also produced approximately 4.80M i/s for both rewritten methods and plain Ruby.

---

## 18.4 Supporting Infrastructure Was Improved

The project also resolved or improved:

- subclass type validation
- class binding capture
- user-defined constant resolution
- repeated Struct allocation
- parameter value handling
- method signature reconstruction

---

# 19. What I Learned

## Ruby Metaprogramming

The project provided substantial experience with Ruby's:

- `class_eval`
- `TracePoint`
- `Binding`
- method definitions
- method visibility
- inheritance
- constant resolution

Understanding the interaction between these mechanisms was essential to implementing method rewriting correctly.

---

## Runtime Performance Analysis

The project reinforced the importance of measuring actual runtime behavior rather than relying only on implementation assumptions.

Benchmarking the existing shim against the rewritten implementation and plain Ruby made the performance impact measurable.

The object-reuse experiment also demonstrated how benchmark design and allocations can influence observed results.

---

## Open Source Development

The project involved:

- breaking work into reviewable PRs
- identifying and tracking issues
- writing tests alongside implementation changes
- responding to implementation problems
- documenting changes
- benchmarking proposed improvements
- iterating toward an upstream-compatible solution

---

## Debugging Through Underlying Behavior

Several issues required investigation beyond the immediate error.

The class-binding and constant-resolution work was particularly valuable in understanding how Ruby's execution context affects metaprogramming and runtime evaluation.

---

# 20. Conclusion

The GSoC 2026 project successfully implemented the core method rewriting approach intended to eliminate the additional untyped shim layer in LowType.

The work produced a new `rewrite_methods` mode, supporting infrastructure in Lowkey and LowType, extensive testing, performance evaluation, and documentation.

The benchmark results demonstrate a substantial performance improvement over the existing shim implementation for keyword arguments while maintaining performance close to plain Ruby.

The supporting changes have been merged, while the primary GSoC deliverable is currently under review in PR #45.

The remaining work consists primarily of completing the upstream review process, performing broader end-to-end validation, and addressing additional Ruby edge cases identified during development.

The implementation provides a foundation for reducing the runtime overhead associated with untyped method shims while preserving Ruby method behavior and enabling future improvements.

---

# 21. Complete Contribution Index

## Lowkey

| PR                                              | Contribution                                       | Status |
| ----------------------------------------------- | -------------------------------------------------- | ------ |
| [#6](https://github.com/low-rb/lowkey/pull/6)   | Add `class_binding` to `ClassProxy`                | Merged |
| [#9](https://github.com/low-rb/lowkey/pull/9)   | Add `export(typed: false)` and `rewrite_signature` | Merged |
| [#10](https://github.com/low-rb/lowkey/pull/10) | Fix `ValueExpression` unwrapping                   | Merged |
| [#11](https://github.com/low-rb/lowkey/pull/11) | Normalize `LOWKEY_UNDEFINED`                       | Merged |

## LowType

| PR                                                | Contribution                                  | Status       |
| ------------------------------------------------- | --------------------------------------------- | ------------ |
| [#29](https://github.com/low-rb/low_type/pull/29) | Replace strict class equality with `is_a?`    | Merged       |
| [#35](https://github.com/low-rb/low_type/pull/35) | Fix repeated `Struct.new` allocation          | Merged       |
| [#39](https://github.com/low-rb/low_type/pull/39) | Capture class binding using `TracePoint :end` | Merged       |
| [#40](https://github.com/low-rb/low_type/pull/40) | Add `class_evaluate`                          | Merged       |
| [#45](https://github.com/low-rb/low_type/pull/45) | Add `rewrite_methods` to `Redefiner`          | Under Review |

## Issues

- [Issue #28](https://github.com/low-rb/low_type/issues/28) — Subclass type checking bug
- [Issue #31](https://github.com/low-rb/low_type/issues/31) — User-defined constant resolution
- [Issue #35](https://github.com/low-rb/low_type/issues/35) — `Struct.new` allocation overhead
- [Issue #38](https://github.com/low-rb/low_type/issues/38) — Method rewriting / GSoC deliverable
- [Issue #40](https://github.com/low-rb/low_type/issues/40) — Original-binding constant evaluation

---

# 22. Final Status

**Project:** Eliminating Shim Methods via Method Rewriting in LowType

**Core implementation:** Implemented

**Supporting infrastructure:** Completed

**Testing:** 170 reported examples, 0 failures

**Performance evaluation:** Completed

**Documentation:** Updated

**Merged upstream:** Supporting Lowkey and LowType contributions listed above

**Primary GSoC deliverable:** [PR #45](https://github.com/low-rb/low_type/pull/45), under review

**Remaining work:** Upstream review/merge, end-to-end validation, and additional edge-case coverage
</details>