### PR TITLE
Fix untyped_args misreading keyword params as positional

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 **✨ Features:**
 - Inline types
 - Enable/disable per environment
-- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Integrates with [Sinatra](#sinatra) and [Raindeer](http://raindeer.dev) frameworks
 - Exports to RBS [UNRELEASED]
 - Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ class MyClass
 end
 ```
 
+**✨ Features:**
+- Inline types
+- Enable/disable per environment
+- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Exports to RBS [UNRELEASED]
+- Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
+
 ## Default values
 
 Place `|` after the type definition to provide a default value when the argument is `nil`:

--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -37,14 +37,16 @@ module Low
 
       def untyped_args(args:, kwargs:, method_proxy:) # rubocop:disable Metrics/AbcSize
         method_proxy.params_with_expressions.each do |param_proxy|
-          value = param_proxy.position ? args[param_proxy.position] : kwargs[param_proxy.name]
+          positional = %i[pos_req pos_opt].include?(param_proxy.type)
+
+          value = positional ? args[param_proxy.position] : kwargs[param_proxy.name]
 
           next unless value.nil?
           raise param_proxy.error_type, param_proxy.error_message(value:) if param_proxy.expression.required?
 
           value = param_proxy.expression.default_value # Default value can still be `nil`.
           value = value.value if value.is_a?(ValueExpression)
-          param_proxy.position ? args[param_proxy.position] = value : kwargs[param_proxy.name] = value
+          positional ? args[param_proxy.position] = value : kwargs[param_proxy.name] = value
         end
 
         [args, kwargs]

--- a/spec/features/type_checking_spec.rb
+++ b/spec/features/type_checking_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe 'LowType.config.type_checking' do
         end
       end
     end
+
+    describe '#typed_kwarg' do
+      it 'passes through the keyword argument' do
+        expect(type_checking.typed_kwarg(greeting: 'Hi')).to eq('Hi')
+      end
+
+      context 'when kwarg is correct type' do
+        it 'accepts the typed kwarg' do
+          expect { type_checking.typed_kwarg(greeting: 'Yo') }.not_to raise_error
+        end
+      end
+
+      context 'when kwarg is wrong type' do
+        it 'accepts the wrongly typed kwarg' do
+          expect { type_checking.typed_kwarg(greeting: 123) }.not_to raise_error
+        end
+      end
+    end
   end
 
   context 'when type checking is enabled' do
@@ -48,6 +66,24 @@ RSpec.describe 'LowType.config.type_checking' do
       context 'when arg is wrong type' do
         it 'raises an argument type error' do
           expect { type_checking.typed_arg(123) }.to raise_error(Low::ArgumentTypeError)
+        end
+      end
+    end
+
+    describe '#typed_kwarg' do
+      it 'passes through the keyword argument' do
+        expect(type_checking.typed_kwarg(greeting: 'Hi')).to eq('Hi')
+      end
+
+      context 'when kwarg is correct type' do
+        it 'accepts the typed kwarg' do
+          expect { type_checking.typed_kwarg(greeting: 'Yo') }.not_to raise_error
+        end
+      end
+
+      context 'when kwarg is wrong type' do
+        it 'raises an argument type error' do
+          expect { type_checking.typed_kwarg(greeting: 123) }.to raise_error(Low::ArgumentTypeError)
         end
       end
     end

--- a/spec/fixtures/type_checking_disabled.rb
+++ b/spec/fixtures/type_checking_disabled.rb
@@ -8,4 +8,8 @@ class TypeCheckingDisabled
   def typed_arg(greeting = String)
     greeting
   end
+
+  def typed_kwarg(greeting: String)
+    greeting
+  end
 end

--- a/spec/fixtures/type_checking_enabled.rb
+++ b/spec/fixtures/type_checking_enabled.rb
@@ -8,4 +8,8 @@ class TypeCheckingEnabled
   def typed_arg(greeting = String)
     greeting
   end
+
+  def typed_kwarg(greeting: String)
+    greeting
+  end
 end


### PR DESCRIPTION
## Summary

`Redefiner.untyped_args` (the path used when `config.type_checking` is `false`) decided positional-vs-keyword by checking `param_proxy.position` truthiness:

```ruby
value = param_proxy.position ? args[param_proxy.position] : kwargs[param_proxy.name]
```

But keyword params also carry a non-nil `.position` (their ordinal position among *all* params, not just positional ones) — so a keyword-typed param like `greeting: String` gets misread as positional and looked up as `args[position]`, which is empty for a keyword call. That reads as `nil`, which trips the "required but missing" check and raises `Low::ArgumentTypeError` — even with type checking supposedly disabled. This means `type_checking = false` is currently unusable for any class with keyword type expressions.

The working `typed_methods` path already decides this correctly, checking `.type` instead:

```ruby
positional = %i[pos_req pos_opt].include?(param_proxy.type)
```

## Fix

Use that same check in `untyped_args` instead of the position-truthiness check.

## Verification

- Added `#typed_kwarg` to both `type_checking_disabled`/`type_checking_enabled` fixtures and mirrored the existing `#typed_arg` test cases for it.
- Confirmed the new tests actually catch the bug: stashed just the `redefiner.rb` fix and reran — 3 of the new tests fail with exactly the described `Low::ArgumentTypeError`, confirming they exercise the real bug rather than being incidentally green.
- Full suite: 147 examples (141 existing + 6 new), same 10 pre-existing failures as `main` (all Ruby-version-dependent formatting differences in hash/error-message output, unrelated to this change).