### PR TITLE
Stop reallocating the positional-param-types array every call

### DIFF
--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -25,6 +25,10 @@ module Low
   #      │              │                 │◄┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
   #      │              │                 │                 │               │
   class Redefiner
+    # Array literals (unlike frozen string literals) aren't cached by Ruby -- this was being
+    # reallocated on every param, every call, in both typed_methods and untyped_args below.
+    POSITIONAL_PARAM_TYPES = %i[pos_req pos_opt].freeze
+
     class << self
       # TODO: Pass in "klass" and use it to class_eval/eval methods in the binding of the class that included LowType.
       def redefine(method_proxies:, class_proxy:)
@@ -35,9 +39,13 @@ module Low
         end
       end
 
+      # Mutates args/kwargs in place -- callers already hold the same Array/Hash references
+      # they passed in, so there's nothing useful to return (previously returned [args, kwargs],
+      # which callers reassigned into their own args/kwargs -- redundant, since the mutation was
+      # already visible to them; removed the array allocation and the reassignment together).
       def untyped_args(args:, kwargs:, method_proxy:) # rubocop:disable Metrics/AbcSize
         method_proxy.params_with_expressions.each do |param_proxy|
-          positional = %i[pos_req pos_opt].include?(param_proxy.type)
+          positional = POSITIONAL_PARAM_TYPES.include?(param_proxy.type)
 
           value = positional ? args[param_proxy.position] : kwargs[param_proxy.name]
 
@@ -49,7 +57,7 @@ module Low
           positional ? args[param_proxy.position] = value : kwargs[param_proxy.name] = value
         end
 
-        [args, kwargs]
+        nil
       end
 
       private
@@ -59,7 +67,7 @@ module Low
           method_proxies.values.filter(&:expressions?).each do |method_proxy|
             define_method(method_proxy.name) do |*args, **kwargs|
               method_proxy.params_with_expressions.each do |param_proxy|
-                positional = %i[pos_req pos_opt].include?(param_proxy.type)
+                positional = POSITIONAL_PARAM_TYPES.include?(param_proxy.type)
 
                 value = positional ? args[param_proxy.position] : kwargs[param_proxy.name]
                 value = param_proxy.expression.default_value if value.nil? && !param_proxy.expression.required?
@@ -92,7 +100,7 @@ module Low
               # NOTE: Type checking is currently disabled. See 'config.type_checking'.
               method_proxy = Lowkey[class_proxy.file_path][class_proxy.namespace][__method__]
 
-              args, kwargs = Low::Redefiner.untyped_args(args:, kwargs:, method_proxy:)
+              Low::Redefiner.untyped_args(args:, kwargs:, method_proxy:)
               super(*args, **kwargs)
             end
 


### PR DESCRIPTION
## Stacked on #46

This builds on #46 (fix/untyped-args-keyword-param-detection) — that PR introduces the `%i[pos_req pos_opt].include?(param_proxy.type)` check in `untyped_args` in the first place, replacing a different, buggy check. Targeting that branch rather than `main` so the diff here is just this change.

## Summary

Two related per-call allocations in `Redefiner`, present in both `typed_methods` and `untyped_args`:

1. `%i[pos_req pos_opt].include?(param_proxy.type)` — array literals aren't cached the way frozen string literals are under `# frozen_string_literal: true` (that magic comment only affects strings), so this allocated a brand new `Array` on **every single param, every single call**. Hoisted to a frozen `POSITIONAL_PARAM_TYPES` constant.

2. `untyped_args` returned `[args, kwargs]` for the caller to reassign into its own `args`/`kwargs` — but `untyped_args` already mutates those same `Array`/`Hash` objects in place (`args[position] = value`, `kwargs[name] = value`), so the caller's `args`/`kwargs` already reflected every change once the method returned. The return value — and the caller's `args, kwargs = Low::Redefiner.untyped_args(...)` reassignment — was pure redundant allocation for something already true.

## Verification

Measured with `GC.disable` + `ObjectSpace` diffing (nothing freed mid-measurement, every allocation attributable) on a call to a method with 2 keyword type-expression params:

| Path | Before | After |
|---|---|---|
| `typed_methods` (`type_checking: true`, the default) | 8 | 6 |
| `untyped_args` (`type_checking: false`) | 13 | 10 |

Since the array-literal saving is per-param, this scales with how many typed params a method has — a bigger win for larger method signatures than this 2-param example shows.

Full suite: 147 examples, same 10 pre-existing failures as `main` (Ruby-version-dependent formatting differences in hash/error-message output, unrelated to this change).