### PR TITLE
Add LowType.freeze_config! for Ractor-safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 **✨ Features:**
 - Inline types
 - Enable/disable per environment
-- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Integrates with [Sinatra](#sinatra) and [Raindeer](http://raindeer.dev) frameworks
 - Exports to RBS [UNRELEASED]
 - Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ class MyClass
 end
 ```
 
+**✨ Features:**
+- Inline types
+- Enable/disable per environment
+- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Exports to RBS [UNRELEASED]
+- Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
+
 ## Default values
 
 Place `|` after the type definition to provide a default value when the argument is `nil`:

--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -80,5 +80,15 @@ module LowType
     def configure
       yield(config)
     end
+
+    # Freezes the config, making it shareable across Ractors (Class/Module instance
+    # variables can only be read from a non-main Ractor if their value is frozen --
+    # otherwise every 'if LowType.config.type_checking' check in a typed/untyped
+    # method call raises Ractor::IsolationError). Call once, after all #configure
+    # calls, before spawning any worker Ractors -- #configure can no longer mutate
+    # the config afterwards, same as any other frozen object.
+    def freeze_config!
+      config.freeze
+    end
   end
 end

--- a/spec/units/low_type_spec.rb
+++ b/spec/units/low_type_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+
+RSpec.describe LowType do
+  after { LowType.instance_variable_set(:@config, nil) }
+
+  describe '.freeze_config!' do
+    it 'freezes the config object' do
+      LowType.freeze_config!
+
+      expect(LowType.config).to be_frozen
+    end
+
+    it 'prevents further mutation via #configure' do
+      LowType.freeze_config!
+
+      expect { LowType.configure { |config| config.type_checking = false } }.to raise_error(FrozenError)
+    end
+  end
+end


### PR DESCRIPTION
## What

`LowType.config` is a mutable `Struct` memoized as an instance variable on the
`LowType` module (`@config ||= Config.new(...)`). Reading it from a non-main
Ractor raises:

```
Ractor::IsolationError: can not get unshareable values from instance variables
of classes/modules from non-main Ractors
```

(confirmed empirically -- see repro below). Since every typed/untyped method
call checks `LowType.config.type_checking`, this makes any class using
`LowType` uncallable from a worker Ractor, full stop.

## Fix

`LowType.freeze_config!` freezes the config object. Call it once, after all
`#configure` calls, before spawning any worker Ractors. `#configure` can no
longer mutate the config afterward -- same as any other frozen object, and the
right tradeoff for a value meant to be decided once at boot, not changed
per-request.

## Repro (confirms the problem this fixes)

```ruby
Config = Struct.new(:type_checking)
module M
  class << self
    def config
      @config ||= Config.new(true)
    end
  end
end
M.config # main Ractor

r = Ractor.new { M.config.type_checking }
r.take
# => Ractor::IsolationError: can not get unshareable values from instance
#    variables of classes/modules from non-main Ractors

M.config.freeze
r = Ractor.new { M.config.type_checking }
r.take
# => true (works)
```

## Testing

- New unit spec: `spec/units/low_type_spec.rb` -- freezes, and confirms
  `#configure` raises `FrozenError` afterward.
- Full suite: 143 examples, 0 failures.
- Rubocop clean on the changed file (one pre-existing, unrelated
  `Metrics/AbcSize` offense on `.included` -- confirmed present on `main`
  before this change too).

Part of a broader look at what it'd take to make Raindeer's stack Ractor-safe;
this is the first, lowest-risk piece. Two follow-up PRs (clearing a captured
`Binding` that blocks freezing the `Lowkey` registry, and a per-class
`ractor_safe!` opt-in for the method-wrapping codegen) are incoming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)