### PR TITLE
Clear class_proxy.class_binding after its one-time use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 **✨ Features:**
 - Inline types
 - Enable/disable per environment
-- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Integrates with [Sinatra](#sinatra) and [Raindeer](http://raindeer.dev) frameworks
 - Exports to RBS [UNRELEASED]
 - Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ class MyClass
 end
 ```
 
+**✨ Features:**
+- Inline types
+- Enable/disable per environment
+- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Exports to RBS [UNRELEASED]
+- Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
+
 ## Default values
 
 Place `|` after the type definition to provide a default value when the argument is `nil`:

--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -52,6 +52,14 @@ module LowType
 
       Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods, class_binding: class_proxy.class_binding)
 
+      # class_binding's only job is evaluating default/type-expression values (e.g. the bare
+      # `String` in `def method(var: String)`) against the class's own lexical scope, right above --
+      # nothing reads it afterward. Clearing it here matters beyond just freeing a Binding: a
+      # Binding can never be made Ractor-shareable, even frozen (Ractor.make_shareable raises
+      # Ractor::Error unconditionally for one), so leaving a live Binding on class_proxy would
+      # permanently block sharing Lowkey's whole file/class/method-proxy registry across Ractors.
+      class_proxy.class_binding = nil
+
       klass.prepend Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:)
       klass.singleton_class.prepend Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:)
 

--- a/spec/units/class_binding_spec.rb
+++ b/spec/units/class_binding_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+require_relative '../fixtures/return_types'
+
+RSpec.describe 'class_proxy.class_binding' do
+  subject(:class_proxy) { Lowkey['spec/fixtures/return_types.rb']['ReturnTypes'] }
+
+  it 'is cleared once the class has finished loading' do
+    # class_binding's only job is evaluating default/type-expression values against the
+    # class's own lexical scope, done once while the class body loads. A live Binding can
+    # never be made Ractor-shareable (even frozen), so leaving one behind on class_proxy
+    # would permanently block sharing Lowkey's registry across Ractors.
+    expect(class_proxy.class_binding).to be_nil
+  end
+end


### PR DESCRIPTION
## What

`class_proxy.class_binding` captures the class body's `Binding` via `TracePoint
:end`, used once to `eval` default/type-expression values (e.g. the bare
`String` in `def method(var: String)`) against the class's own lexical scope.
I checked every consumer across `low_type`, `lowkey`, and every gem that
depends on either -- nothing reads it after that one evaluation.

Leaving it set matters for more than tidiness: a `Binding` can **never** be
made Ractor-shareable, even frozen:

```ruby
b = binding
b.freeze          # => succeeds, b.frozen? == true
Ractor.make_shareable(b)
# => Ractor::Error: can not make shareable object for #<Binding:0x...>
```

So a live `Binding` sitting on `class_proxy` -- which lives inside `Lowkey.keys`,
the file/class/method-proxy registry every `LowType`-included class is stored
in -- permanently blocks `Ractor.make_shareable(Lowkey.keys)`, i.e. sharing
that whole registry across Ractors, regardless of anything else.

## Fix

Set `class_proxy.class_binding = nil` right after the one evaluation that
needs it. Confirmed via `Adapter::Loader.load` (the only other thing that runs
in the same `TracePoint` callback) that nothing downstream touches it either.

## Testing

- New spec: `spec/units/class_binding_spec.rb` -- loads a real fixture class
  and asserts `class_binding` is `nil` afterward.
- Full suite: 142 examples, 0 failures.
- Rubocop clean (one pre-existing, unrelated `Metrics/AbcSize` offense on
  `.included`, present on `main` before this change).

Second of three PRs from a look at what it'd take to make Raindeer's stack
Ractor-safe (see #49 for the first). This one is necessary but not
sufficient -- `Lowkey` itself still needs a way to actually call
`Ractor.make_shareable` on its registry; that's a separate PR against the
`lowkey` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)