### PR TITLE
Add per-class ractor_safe! opt-in for Redefiner's method codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 **✨ Features:**
 - Inline types
 - Enable/disable per environment
-- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Integrates with [Sinatra](#sinatra) and [Raindeer](http://raindeer.dev) frameworks
 - Exports to RBS [UNRELEASED]
 - Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ class MyClass
 end
 ```
 
+**✨ Features:**
+- Inline types
+- Enable/disable per environment
+- Integrates with [Sinatra](http://sinatrarb.com/intro.html) and [Raindeer](http://raindeer.dev) frameworks
+- Exports to RBS [UNRELEASED]
+- Uninstall easily: `lowtype uninstall`, that's it! [UNRELEASED]
+
 ## Default values
 
 Place `|` after the type definition to provide a default value when the argument is `nil`:

--- a/lib/definitions/ractor_safety.rb
+++ b/lib/definitions/ractor_safety.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Low
+  # Opt-in, per class: `ractor_safe!` in the class body switches Redefiner's codegen
+  # from define_method blocks (fast, but Proc-backed methods can't be called from a
+  # Ractor other than the one that defined them) to class_eval'd source strings (real
+  # methods, callable from any Ractor once Lowkey.make_shareable! has been called).
+  # Most classes never run inside a worker Ractor and shouldn't pay for the per-call
+  # registry lookup the ractor-safe path requires -- see Redefiner.redefine.
+  module RactorSafety
+    def ractor_safe!
+      @ractor_safe = true
+    end
+
+    def ractor_safe?
+      @ractor_safe || false
+    end
+  end
+end

--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -27,11 +27,22 @@ module Low
   class Redefiner
     class << self
       # TODO: Pass in "klass" and use it to class_eval/eval methods in the binding of the class that included LowType.
-      def redefine(method_proxies:, class_proxy:)
+      #
+      # ractor_safe: false (default) defines methods via define_method blocks, closing over
+      # method_proxy directly -- fast, but the resulting method is backed by a Proc, and Ruby
+      # refuses to call a Proc-backed method from any Ractor other than the one that defined
+      # it, even with zero closure captures and even if everything captured is frozen. true
+      # instead compiles each method from a source string via class_eval, producing a real
+      # method with no Ractor affinity, at the cost of re-deriving method_proxy from Lowkey's
+      # registry on every call instead of closing over it once. Only useful once that registry
+      # has actually been made shareable (see Lowkey.make_shareable!) -- opt in per class via
+      # `ractor_safe!`, not globally, since most classes never run inside a worker Ractor and
+      # shouldn't pay for a per-call registry lookup they don't need.
+      def redefine(method_proxies:, class_proxy:, ractor_safe: false)
         if LowType.config.type_checking
-          typed_methods(method_proxies:, class_proxy:)
+          typed_methods(method_proxies:, class_proxy:, ractor_safe:)
         else
-          untyped_methods(method_proxies:, class_proxy:)
+          untyped_methods(method_proxies:, class_proxy:, ractor_safe:)
         end
       end
 
@@ -52,29 +63,33 @@ module Low
 
       private
 
-      def typed_methods(method_proxies:, class_proxy:) # rubocop:disable Metrics
+      def typed_methods(method_proxies:, class_proxy:, ractor_safe: false) # rubocop:disable Metrics
         Module.new do
           method_proxies.values.filter(&:expressions?).each do |method_proxy|
-            define_method(method_proxy.name) do |*args, **kwargs|
-              method_proxy.params_with_expressions.each do |param_proxy|
-                positional = %i[pos_req pos_opt].include?(param_proxy.type)
+            if ractor_safe
+              Low::Redefiner.define_ractor_safe_typed_method(mod: self, method_proxy:, class_proxy:)
+            else
+              define_method(method_proxy.name) do |*args, **kwargs|
+                method_proxy.params_with_expressions.each do |param_proxy|
+                  positional = %i[pos_req pos_opt].include?(param_proxy.type)
 
-                value = positional ? args[param_proxy.position] : kwargs[param_proxy.name]
-                value = param_proxy.expression.default_value if value.nil? && !param_proxy.expression.required?
+                  value = positional ? args[param_proxy.position] : kwargs[param_proxy.name]
+                  value = param_proxy.expression.default_value if value.nil? && !param_proxy.expression.required?
 
-                param_proxy.expression.validate!(value:, proxy: param_proxy)
-                value = value.value if value.is_a?(ValueExpression)
+                  param_proxy.expression.validate!(value:, proxy: param_proxy)
+                  value = value.value if value.is_a?(ValueExpression)
 
-                positional ? args[param_proxy.position] = value : kwargs[param_proxy.name] = value
+                  positional ? args[param_proxy.position] = value : kwargs[param_proxy.name] = value
+                end
+
+                if (return_proxy = method_proxy.return_proxy)
+                  return_value = super(*args, **kwargs)
+                  return_proxy.expression.validate!(value: return_value, proxy: return_proxy)
+                  return return_value
+                end
+
+                super(*args, **kwargs)
               end
-
-              if (return_proxy = method_proxy.return_proxy)
-                return_value = super(*args, **kwargs)
-                return_proxy.expression.validate!(value: return_value, proxy: return_proxy)
-                return return_value
-              end
-
-              super(*args, **kwargs)
             end
 
             private method_proxy.name if class_proxy.private_start_line && method_proxy.start_line > class_proxy.private_start_line
@@ -82,22 +97,75 @@ module Low
         end
       end
 
-      def untyped_methods(method_proxies:, class_proxy:)
+      def untyped_methods(method_proxies:, class_proxy:, ractor_safe: false) # rubocop:disable Metrics/AbcSize
         Module.new do
           method_proxies.values.filter(&:expressions?).each do |method_proxy|
-            # You are now in the binding of the includer class.
-            define_method(method_proxy.name) do |*args, **kwargs|
-              # NOTE: Type checking is currently disabled. See 'config.type_checking'.
-              method_proxy = Lowkey[class_proxy.file_path][class_proxy.namespace][__method__]
+            if ractor_safe
+              Low::Redefiner.define_ractor_safe_untyped_method(mod: self, method_proxy:, class_proxy:)
+            else
+              # You are now in the binding of the includer class.
+              define_method(method_proxy.name) do |*args, **kwargs|
+                # NOTE: Type checking is currently disabled. See 'config.type_checking'.
+                method_proxy = Lowkey[class_proxy.file_path][class_proxy.namespace][__method__]
 
-              args, kwargs = Low::Redefiner.untyped_args(args:, kwargs:, method_proxy:)
-              super(*args, **kwargs)
+                args, kwargs = Low::Redefiner.untyped_args(args:, kwargs:, method_proxy:)
+                super(*args, **kwargs)
+              end
             end
 
             private method_proxy.name if class_proxy.private_start_line && method_proxy.start_line > class_proxy.private_start_line
           end
         end
       end
+
+      public
+
+      # Compiled from a source string (not define_method) so the result is a real method with
+      # no Ractor affinity -- see the comment on .redefine. method_proxy is re-derived from
+      # Lowkey's registry every call rather than closed over, since a string can't capture a
+      # local variable the way a block can.
+      # rubocop:disable Style/EvalWithLocation -- attributing these to the fixture/app's own
+      # file and line, not redefiner.rb's __FILE__, is the point: it's what makes a
+      # validation error's backtrace point at the user's actual method definition.
+      def define_ractor_safe_typed_method(mod:, method_proxy:, class_proxy:)
+        mod.class_eval(<<~RUBY, class_proxy.file_path, method_proxy.start_line)
+          def #{method_proxy.name}(*args, **kwargs)
+            method_proxy = Lowkey[#{class_proxy.file_path.inspect}][#{class_proxy.namespace.inspect}][__method__]
+
+            method_proxy.params_with_expressions.each do |param_proxy|
+              positional = %i[pos_req pos_opt].include?(param_proxy.type)
+
+              value = positional ? args[param_proxy.position] : kwargs[param_proxy.name]
+              value = param_proxy.expression.default_value if value.nil? && !param_proxy.expression.required?
+
+              param_proxy.expression.validate!(value:, proxy: param_proxy)
+              value = value.value if value.is_a?(Low::ValueExpression)
+
+              positional ? args[param_proxy.position] = value : kwargs[param_proxy.name] = value
+            end
+
+            if (return_proxy = method_proxy.return_proxy)
+              return_value = super(*args, **kwargs)
+              return_proxy.expression.validate!(value: return_value, proxy: return_proxy)
+              return return_value
+            end
+
+            super(*args, **kwargs)
+          end
+        RUBY
+      end
+
+      def define_ractor_safe_untyped_method(mod:, method_proxy:, class_proxy:)
+        mod.class_eval(<<~RUBY, class_proxy.file_path, method_proxy.start_line)
+          def #{method_proxy.name}(*args, **kwargs)
+            method_proxy = Lowkey[#{class_proxy.file_path.inspect}][#{class_proxy.namespace.inspect}][__method__]
+
+            args, kwargs = Low::Redefiner.untyped_args(args:, kwargs:, method_proxy:)
+            super(*args, **kwargs)
+          end
+        RUBY
+      end
+      # rubocop:enable Style/EvalWithLocation
     end
   end
 end

--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -3,6 +3,7 @@
 require 'lowkey'
 
 require_relative 'adapters/adapter_loader'
+require_relative 'definitions/ractor_safety'
 require_relative 'definitions/redefiner'
 require_relative 'definitions/type_accessors'
 require_relative 'expressions/expression_helpers'
@@ -41,6 +42,7 @@ module LowType
     klass.extend Low::ExpressionHelpers
     klass.extend Low::TypeAccessors
     klass.extend Low::Types
+    klass.extend Low::RactorSafety
 
     # Use TracePoint :end to capture the class binding after the class body finishes loading.
     # At :end time, trace.self is the including class and trace.binding is the class body's binding,
@@ -52,8 +54,9 @@ module LowType
 
       Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods, class_binding: class_proxy.class_binding)
 
-      klass.prepend Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:)
-      klass.singleton_class.prepend Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:)
+      ractor_safe = klass.ractor_safe?
+      klass.prepend Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:, ractor_safe:)
+      klass.singleton_class.prepend Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:, ractor_safe:)
 
       Low::Adapter::Loader.load(klass:, class_proxy:)
 

--- a/spec/features/ractor_safety_spec.rb
+++ b/spec/features/ractor_safety_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+
+RSpec.describe 'ractor_safe!' do
+  # Lowkey.make_shareable! freezes the *entire shared* registry -- every other fixture
+  # in the suite lives in it too. Proving cross-Ractor callability in-process would mean
+  # either wiping that registry (breaking any later spec that expects an already-loaded
+  # fixture still cached, without re-`Lowkey.load`ing it) or leaving it frozen (breaking
+  # any later spec that loads a new fixture at all). Running the actual Ractor proof in
+  # a subprocess sidesteps that entirely -- nothing about the shared suite process's
+  # Lowkey.keys is touched.
+  def run_in_subprocess(fixture_path, class_name)
+    output = `bundle exec ruby -I lib -e "
+      require_relative '#{fixture_path}'
+      # Simulates low-rb/low_type#50 (clearing class_proxy.class_binding once a class has
+      # finished loading) inline, rather than depending on that PR having landed here too --
+      # a live Binding can never be made Ractor-shareable, even frozen, so without this
+      # Lowkey.make_shareable! would raise for any class_proxy LowType has touched.
+      Lowkey['#{fixture_path}.rb']['#{class_name}'].class_binding = nil
+      Lowkey.make_shareable!
+      ractor = Ractor.new { #{class_name}.new.greet('Hi') }
+      puts ractor.take
+    " 2>&1`
+    output.lines.last&.strip
+  end
+
+  context 'with type checking enabled' do
+    subject(:instance) { RactorSafeTyped.new }
+
+    LowType.configure { |config| config.type_checking = true }
+    require_relative '../fixtures/ractor_safe_typed'
+
+    it 'still validates params like a normal typed method' do
+      expect(instance.greet('Hi')).to eq('Hi')
+      expect { instance.greet(123) }.to raise_error(Low::ArgumentTypeError)
+    end
+
+    it 'is callable from a worker Ractor once Lowkey is made shareable' do
+      expect(run_in_subprocess('spec/fixtures/ractor_safe_typed', 'RactorSafeTyped')).to eq('Hi')
+    end
+  end
+
+  context 'with type checking disabled' do
+    subject(:instance) { RactorSafeUntyped.new }
+
+    LowType.configure { |config| config.type_checking = false }
+    require_relative '../fixtures/ractor_safe_untyped'
+    LowType.configure { |config| config.type_checking = true }
+
+    it 'still passes through untyped, unvalidated' do
+      expect(instance.greet(123)).to eq(123)
+    end
+
+    it 'is callable from a worker Ractor once Lowkey is made shareable' do
+      expect(run_in_subprocess('spec/fixtures/ractor_safe_untyped', 'RactorSafeUntyped')).to eq('Hi')
+    end
+  end
+end

--- a/spec/fixtures/ractor_safe_typed.rb
+++ b/spec/fixtures/ractor_safe_typed.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+
+class RactorSafeTyped
+  include LowType
+  ractor_safe!
+
+  def greet(name = String)
+    name
+  end
+end

--- a/spec/fixtures/ractor_safe_untyped.rb
+++ b/spec/fixtures/ractor_safe_untyped.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+
+class RactorSafeUntyped
+  include LowType
+  ractor_safe!
+
+  def greet(name = String)
+    name
+  end
+end


### PR DESCRIPTION
## What

`Redefiner.typed_methods`/`untyped_methods` wrap every method via
`define_method` blocks closing over `method_proxy`. I confirmed empirically
that this makes the resulting method uncallable from any Ractor other than
the one that defined it, **regardless of whether the closure captures
anything, and regardless of whether captured state is frozen**:

```ruby
wrapper = Module.new do
  define_method(:greet) { |name| super(name.upcase) } # zero outer captures
end
Target.prepend(wrapper)

Ractor.new { Target.new.greet('hi') }.take
# => RuntimeError: defined with an un-shareable Proc in a different Ractor
```

A method compiled from a source **string** via `class_eval` doesn't have this
restriction -- it's a real, ISeq-backed method, not a Proc:

```ruby
wrapper.class_eval(<<~RUBY)
  def greet(name)
    proxy = REGISTRY[:greet]  # shareable lookup, not a closure
    super(proxy.validate ? name.upcase : name)
  end
RUBY
# callable from any Ractor, confirmed
```

## Fix

`ractor_safe!` in a class body (extended via the new `Low::RactorSafety`
mixin) opts that one class into the `class_eval`-string codegen path
(`Redefiner.define_ractor_safe_typed_method`/`_untyped_method`). Every other
class keeps the existing `define_method` path completely unchanged. The
ractor-safe path re-derives `method_proxy` from `Lowkey`'s registry on every
call (`Lowkey[file_path][namespace][__method__]`) instead of closing over it
-- the exact per-call lookup that was removed as a redundant allocation in
`untyped_methods` a while back. That's the real tradeoff: Ractor-callability
costs back some of that allocation win, but only for classes that actually
opt in, not globally.

## Dependencies

This only actually works end-to-end once:
- **low-rb/lowkey#12** -- `Lowkey.make_shareable!` exists, and (as of its
  latest commit) warms `MethodProxy#params_with_expressions`'s lazy cache
  before freezing.
- **#50** -- `class_proxy.class_binding` is cleared once a class finishes
  loading. A live `Binding` can never be made Ractor-shareable, even frozen,
  and blocks `Ractor.make_shareable(Lowkey.keys)` outright otherwise.

This PR's own spec simulates #50 inline (clears `class_binding` manually in
a throwaway subprocess) so its tests pass standalone regardless of merge
order, but real usage needs all three.

## Testing

- Full suite: **145 examples, 0 failures** (up from 141) -- ran the
  pre-existing 141 first, confirmed 0 regressions, before writing anything
  ractor-safe-specific.
- New fixtures (`spec/fixtures/ractor_safe_{typed,untyped}.rb`) +
  `spec/features/ractor_safety_spec.rb`:
  - Confirms validation behavior is identical to the non-ractor-safe path
    (a bad arg still raises `Low::ArgumentTypeError`; type-checking-disabled
    still passes through unvalidated) -- `ractor_safe!` changes codegen
    mechanism only, not behavior.
  - Separately spawns a **real Ractor in a subprocess** (so the shared suite
    process's `Lowkey.keys` registry is never touched -- freezing it
    in-process would break any later spec expecting to load a new fixture)
    and confirms the generated method is actually callable from it, for both
    the typed and untyped codegen branches.
- Rubocop clean bar the same pre-existing, unrelated `Metrics/AbcSize`
  offense on `.included` already on `main`. Added `rubocop:disable
  Style/EvalWithLocation` around the two `class_eval` calls -- deliberately
  attributing generated methods to the app's own file/line, not
  `redefiner.rb`'s `__FILE__`, so a validation error's backtrace points at
  the user's actual method definition.

Third and last of three PRs from a look at what it'd take to make
Raindeer's stack Ractor-safe (see #49 and #50 for the other two, and
low-rb/lowkey#12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)